### PR TITLE
chore: bump Homebrew formula to v0.8.0

### DIFF
--- a/homebrew/echos.rb
+++ b/homebrew/echos.rb
@@ -1,8 +1,8 @@
 class Echos < Formula
   desc "Secure, self-hosted, agent-driven personal knowledge management system"
   homepage "https://github.com/albinotonnina/echos"
-  url "https://github.com/albinotonnina/echos/archive/refs/tags/v0.7.4.tar.gz"
-  sha256 "f725e400c2bde06bf8be29394abd42cfa701296aaee32d048e66b017b445ba3f"
+  url "https://github.com/albinotonnina/echos/archive/refs/tags/v0.8.0.tar.gz"
+  sha256 "13b38d1b7f0de9e7b65f6dfd0be0ddff56a7b9272eff66b189dce685bed6106e"
   license "MIT"
   head "https://github.com/albinotonnina/echos.git", branch: "main"
 


### PR DESCRIPTION
## 📝 Description
Update the Homebrew formula to point to the v0.8.0 release tarball with the correct SHA256 hash.

## 🗂️ Type of Change
- [ ] 🆕 Feature (new functionality or capabilities)
- [ ] 🐛 Bugfix (resolves a problem)
- [ ] 🔄 Refactor (code restructuring without changing functionality)
- [ ] 📚 Docs (documentation updates)
- [x] 🚨 Chore (maintenance, dependencies, tooling, build processes)

## 🔗 Related Azure DevOps Work Items / GitHub Issues
None added.

## 🛠️ What's Changed
1. **Homebrew formula version bump** — Updated the tarball URL from v0.7.4 to v0.8.0 and replaced the SHA256 checksum to match the new release archive.

## ⚠️ Potential Breaking Changes
None.

## 🔒 Security Considerations
No security impact identified.

## �� How Has This Been Tested?
- SHA256 verified by downloading the v0.8.0 tarball and computing the checksum.
- Formula already synced and pushed to the `homebrew-echos` tap repository.

## 🏗️ Architecture/Design Changes
No significant architectural changes were made.

## 📦 Deployment Notes
Standard deployment process applies. The `homebrew-echos` tap has already been updated.

*Created using ASOS Core Create Pull Request Skill*