### PR TITLE
fix(shared): create version logger lazily to avoid module-load side e…

### DIFF
--- a/packages/shared/src/version.ts
+++ b/packages/shared/src/version.ts
@@ -7,8 +7,9 @@ import { createLogger } from './logging/index.js';
  * Walks up the directory tree from this file to find the root package.json
  * (identified by `"name": "echos"`) and returns its version.
  *
- * The result is memoised after the first successful resolution so that
- * repeated calls never hit the filesystem again.
+ * The result is always memoised after the first call (whether the version
+ * was resolved successfully or fell back to `'unknown'`) so that repeated
+ * calls never hit the filesystem again.
  *
  * The logger is created lazily — only if an unexpected error occurs — so
  * importing any symbol from @echos/shared does not instantiate a Pino


### PR DESCRIPTION
…ffect

Instantiating a Pino logger at module scope in version.ts caused every consumer of @echos/shared to pay the logger setup cost on import, even if getVersion() was never called. Move createLogger('version') inside the error-only catch block so no Pino instance is created unless an unexpected I/O or JSON parse error actually occurs.

## What does this PR do?

<!-- A clear, concise description of the change. -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Plugin
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## Testing

<!-- How did you test this? -->

- [ ] Tested locally with `pnpm start`
- [ ] Added / updated tests (`pnpm test`)
- [ ] Typechecks pass (`pnpm typecheck`)

## Security considerations

<!-- Any security implications? New URLs fetched, new user input, new deps? -->
<!-- If none, write "None". -->

## Documentation

<!-- Did you update docs/ if needed? -->

- [ ] Not needed
- [ ] Updated relevant `docs/*.md`
