### PR TITLE
fix: replace QEMU arm64 with native ubuntu-24.04-arm runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,14 +182,6 @@ jobs:
     needs: [prepare, docker-amd64, docker-arm64]
 
     steps:
-      - name: Compute tags
-        id: tags
-        run: |
-          VERSION=${{ needs.prepare.outputs.version }}
-          MAJOR_MINOR=$(echo "$VERSION" | cut -d. -f1,2)
-          IMAGE=ghcr.io/${{ github.repository_owner }}/echos
-          echo "tags=${IMAGE}:${VERSION} ${IMAGE}:${MAJOR_MINOR} ${IMAGE}:latest" >> $GITHUB_OUTPUT
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 


### PR DESCRIPTION
## Problem

The Docker multi-arch build was using QEMU to cross-compile the arm64 image on an x86_64 runner. QEMU emulation crashes with `SIGILL` (signal 4, illegal instruction) when native Node modules (better-sqlite3, lancedb, sharp) compile under emulation. The job then hangs silently until the 60-minute timeout is hit.

This was masked by the Docker layer cache — when the cache was warm the `pnpm install` layer was skipped entirely. The cache is invalidated on every release because the `prepare` job bumps `package.json` versions, which is copied in the first `COPY` instruction of the `deps` stage.

## Fix

Replace the single QEMU-based job with three jobs:

| Job | Runner | What it does |
|---|---|---|
| `docker-amd64` | `ubuntu-latest` | Builds linux/amd64, pushes by digest |
| `docker-arm64` | `ubuntu-24.04-arm` | Builds linux/arm64 natively, pushes by digest |
| `docker-merge` | `ubuntu-latest` | Merges both digests into a tagged multi-arch manifest |

Both build jobs run in parallel, so wall-clock time is also reduced. Each uses its own GHA cache scope (`buildkit-amd64` / `buildkit-arm64`) to prevent cache collisions between platforms.

## Test plan

- [ ] Trigger a patch release and verify all three docker jobs complete successfully
- [ ] Confirm `docker pull ghcr.io/albinotonnina/echos:latest` works and `docker manifest inspect` shows both `linux/amd64` and `linux/arm64` digests

🤖 Generated with [Claude Code](https://claude.com/claude-code)