### PR TITLE
chore: add rollback-release GitHub Actions workflow

### DIFF
--- a/.github/workflows/_deploy-vps.yml
+++ b/.github/workflows/_deploy-vps.yml
@@ -26,6 +26,12 @@ on:
         # once locally) to avoid runtime MITM risk. When absent, falls back to
         # ssh-keyscan (convenient but not MITM-safe).
 
+# Shared concurrency group — enforces mutual exclusion with rollback.yml so
+# that a deploy and a rollback can never run simultaneously on the VPS.
+concurrency:
+  group: deploy-vps
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -8,7 +8,8 @@ on:
         required: true
         type: string
 
-# Share the concurrency group with deploys — only one deploy/rollback at a time.
+# Same concurrency group as _deploy-vps.yml — only one deploy or rollback
+# may run at a time. Both workflows must use this group to enforce mutual exclusion.
 concurrency:
   group: deploy-vps
   cancel-in-progress: false


### PR DESCRIPTION
## Summary

- Adds a manual `workflow_dispatch` workflow for rolling back the VPS to any previously released image version
- Accepts version input like `0.12.4` or `v0.12.4` (leading `v` is stripped automatically to match the Docker tag convention)
- Pulls the pinned version on the VPS, retags it as `:latest`, restarts via `docker compose` — **without touching `.env` or `docker-compose.yml`**
- Shares the `deploy-vps` concurrency group to prevent concurrent deploy/rollback races
- Guarded to `main` branch only (same pattern as `release.yml`)
- Ends with a non-fatal health check (same pattern as `_deploy-vps.yml`)

## How to use

Go to **Actions → Rollback Release → Run workflow**, enter the target version (e.g. `0.12.4`), and click Run.

## Test plan

- [ ] Trigger the workflow from GitHub Actions UI with a valid previous version (e.g. `0.12.4`)
- [ ] Verify the VPS pulls that specific image tag and restarts cleanly
- [ ] Verify `v0.12.4` input also works (leading `v` is stripped)
- [ ] Verify the workflow is blocked if triggered from a non-`main` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)