### PR TITLE
feat: add multi-provider STT abstraction with auto-detection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,15 +55,17 @@ OPENAI_API_KEY=
 
 # Option C: Local Whisper CLI (offline, no API key required)
 # Supports multiple implementations:
-#   1. whisper.cpp (C++):     STT_LOCAL_COMMAND=whisper-cli
-#   2. whispercpp (Python):   STT_LOCAL_COMMAND="python /path/to/whisper-cpp-wrapper.py"
-#   3. openai-whisper:        STT_LOCAL_COMMAND="whisper --model base.en --output_format txt"
-#   4. faster-whisper:        STT_LOCAL_COMMAND="python -m faster_whisper --model base.en"
+#   1. whisper.cpp (C++):     STT_LOCAL_EXECUTABLE=/opt/homebrew/bin/whisper-cli
+#   2. whispercpp (Python):   STT_LOCAL_EXECUTABLE="python /path/to/whisper-cpp-wrapper.py"
+#   3. openai-whisper:        STT_LOCAL_EXECUTABLE="whisper --model base.en --output_format txt"
+#   4. faster-whisper:        STT_LOCAL_EXECUTABLE="python -m faster_whisper --model base.en"
+#
+# STT_LOCAL_MODEL is the full path to the model file (for whisper.cpp),
+# or just the model name (for Python packages).
 #
 # STT_PROVIDER=local
-# STT_LOCAL_COMMAND=whisper-cpp
-# STT_LOCAL_MODEL=base.en
-# STT_LOCAL_MODEL_DIR=/usr/local/share/whisper.cpp/models
+# STT_LOCAL_EXECUTABLE=/opt/homebrew/bin/whisper-cli
+# STT_LOCAL_MODEL=~/whisper-models/ggml-base.en.bin
 
 # Whisper transcription language (ISO-639-1 code, e.g. 'en', 'fr', 'de').
 # Set this if Whisper mis-identifies your language (e.g. transcribes English as Welsh).

--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,45 @@ LLM_BASE_URL=
 # Optional (needed for embeddings, Whisper)
 OPENAI_API_KEY=
 
+# Speech-to-Text (STT) provider — auto-detects from API key by default.
+#
+# Option A: Auto-detect (default, STT_PROVIDER=auto)
+# Provider is detected from API key prefix, base URL, or model name.
+#
+# Auto-detectable by key prefix (just set STT_API_KEY):
+#   OpenAI       — keys start with "sk-"
+#   Groq         — keys start with "gsk_"
+#   Hugging Face — keys start with "hf_"
+#   OpenRouter   — keys start with "sk-or-"
+#
+# NOT auto-detectable by key (opaque keys — set STT_PROVIDER explicitly):
+#   Together AI, SiliconFlow, DeepInfra, Fireworks AI
+#   For these, set STT_PROVIDER + STT_API_KEY (see Option B below).
+#
+# STT_API_KEY=sk-your-openai-key
+# STT_API_KEY=gsk_your-groq-key
+# STT_API_KEY=hf_your-huggingface-key
+# STT_API_KEY=sk-or-your-openrouter-key
+
+# Option B: Explicit provider (needed for Together AI, SiliconFlow, DeepInfra, Fireworks)
+# STT_PROVIDER=openai
+# STT_PROVIDER=groq
+# STT_PROVIDER=together
+# STT_PROVIDER=siliconflow
+# STT_PROVIDER=deepinfra
+# STT_PROVIDER=fireworks
+# STT_PROVIDER=huggingface
+# STT_PROVIDER=openrouter
+# STT_API_KEY=
+# STT_BASE_URL=  # optional — overrides provider default
+# STT_MODEL=     # optional — overrides provider default
+
+# Option C: Local Whisper CLI (whisper.cpp, faster-whisper, etc.)
+# STT_PROVIDER=local
+# STT_LOCAL_COMMAND=whisper-cpp
+# STT_LOCAL_MODEL=base.en
+# STT_LOCAL_MODEL_DIR=/usr/local/share/whisper.cpp/models
+
 # Whisper transcription language (ISO-639-1 code, e.g. 'en', 'fr', 'de').
 # Set this if Whisper mis-identifies your language (e.g. transcribes English as Welsh).
 # If not set, Whisper auto-detects the language.
@@ -49,7 +88,7 @@ EMBEDDING_DIMENSIONS=1536
 ENABLE_TELEGRAM=true
 # Web: HTTP API server for integrations
 ENABLE_WEB=false
-# Show emoji reactions on incoming messages (true/false)
+# Showemoji reactions on incoming messages (true/false)
 TELEGRAM_REACTIONS=true
 
 # Web UI
@@ -69,7 +108,7 @@ WEB_API_KEY=your-secure-web-api-key-here
 # Useful for air-gapped environments with no internet access
 # DISABLE_UPDATE_CHECK=false
 
-# Automated backups
+# Automatedbackups
 # BACKUP_ENABLED=true
 # BACKUP_CRON=0 2 * * *
 # BACKUP_DIR=./data/backups

--- a/.env.example
+++ b/.env.example
@@ -53,7 +53,13 @@ OPENAI_API_KEY=
 # STT_BASE_URL=  # optional — overrides provider default
 # STT_MODEL=     # optional — overrides provider default
 
-# Option C: Local Whisper CLI (whisper.cpp, faster-whisper, etc.)
+# Option C: Local Whisper CLI (offline, no API key required)
+# Supports multiple implementations:
+#   1. whisper.cpp (C++):     STT_LOCAL_COMMAND=whisper-cli
+#   2. whispercpp (Python):   STT_LOCAL_COMMAND="python /path/to/whisper-cpp-wrapper.py"
+#   3. openai-whisper:        STT_LOCAL_COMMAND="whisper --model base.en --output_format txt"
+#   4. faster-whisper:        STT_LOCAL_COMMAND="python -m faster_whisper --model base.en"
+#
 # STT_PROVIDER=local
 # STT_LOCAL_COMMAND=whisper-cpp
 # STT_LOCAL_MODEL=base.en

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -5,6 +5,7 @@ import type { SqliteStorage } from '../storage/sqlite.js';
 import type { MarkdownStorage } from '../storage/markdown.js';
 import type { VectorStorage } from '../storage/vectordb.js';
 import type { SearchService } from '../storage/search.js';
+import type { SpeechToTextClient } from '../stt/index.js';
 
 export interface AgentDeps {
   sqlite: SqliteStorage;
@@ -41,6 +42,8 @@ export interface AgentDeps {
   knowledgeDir?: string;
   /** Path to the database directory containing echos.db and vectors/ (used by knowledge_stats tool) */
   dbPath?: string;
+  /** Speech-to-text client for voice transcription */
+  sttClient?: SpeechToTextClient;
 }
 
 export interface AgentToolDeps {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -64,3 +64,11 @@ export {
   type BackupResult,
   type BackupInfo,
 } from './backup/index.js';
+export {
+  type SpeechToTextClient,
+  type TranscribeOptions,
+  type TranscribeResult,
+  transcribeWithRetry,
+  createSttClient,
+  probeSttProviders,
+} from './stt/index.js';

--- a/packages/core/src/plugins/types.ts
+++ b/packages/core/src/plugins/types.ts
@@ -5,6 +5,7 @@ import type { MarkdownStorage } from '../storage/markdown.js';
 import type { VectorStorage } from '../storage/vectordb.js';
 import type { AgentDeps } from '../agent/index.js';
 import type { NotificationService } from '@echos/shared';
+import type { SpeechToTextClient } from '../stt/index.js';
 
 /**
  * Dependencies provided by core to plugins.
@@ -18,6 +19,7 @@ export interface PluginContext {
   logger: Logger;
   getAgentDeps: () => AgentDeps;
   getNotificationService: () => NotificationService;
+  sttClient?: SpeechToTextClient;
   config: Record<string, unknown> & {
     openaiApiKey?: string;
     anthropicApiKey?: string;

--- a/packages/core/src/stt/factory.ts
+++ b/packages/core/src/stt/factory.ts
@@ -1,0 +1,136 @@
+import type { Config } from '@echos/shared';
+import { ValidationError } from '@echos/shared';
+import type { SpeechToTextClient } from './index.js';
+import { OpenAICompatibleClient } from './openai-compatible-client.js';
+import { LocalWhisperClient } from './local-whisper-client.js';
+import {
+  detectProviderFromKey,
+  detectProviderFromModel,
+  detectProviderFromUrl,
+  getProviderInfo,
+  getProbeableProviders,
+  probeProvider,
+  loadCachedProvider,
+  saveCachedProvider,
+  STT_PROVIDERS,
+} from './registry.js';
+
+export async function createSttClient(config: Config): Promise<SpeechToTextClient | undefined> {
+  if (config.sttProvider === 'local') {
+    return createLocalClient(config);
+  }
+
+  if (config.sttProvider !== 'auto') {
+    return createCloudClient(config);
+  }
+
+  const apiKey = config.sttApiKey ?? config.openaiApiKey;
+  if (!apiKey) {
+    return undefined;
+  }
+
+  const detectedProvider = await detectProvider(config, apiKey);
+  if (detectedProvider) {
+    return createClientWithProvider(detectedProvider, apiKey, config);
+  }
+
+  const cached = loadCachedProvider(apiKey);
+  if (cached) {
+    return createClientWithProvider(cached, apiKey, config);
+  }
+
+  // Probe providers with opaque keys (Together AI, SiliconFlow, etc.)
+  const probed = await probeSttProviders(apiKey);
+  if (probed) {
+    return createClientWithProvider(probed.provider, apiKey, config);
+  }
+
+  return undefined;
+}
+
+async function detectProvider(config: Config, apiKey: string): Promise<string | undefined> {
+  if (config.sttBaseUrl) {
+    const fromUrl = detectProviderFromUrl(config.sttBaseUrl);
+    if (fromUrl && fromUrl !== 'local') return fromUrl;
+  }
+
+  if (config.sttModel) {
+    const fromModel = detectProviderFromModel(config.sttModel);
+    if (fromModel && fromModel !== 'local') return fromModel;
+  }
+
+  const fromKey = detectProviderFromKey(apiKey);
+  if (fromKey && fromKey !== 'local') return fromKey;
+
+  return undefined;
+}
+
+function createClientWithProvider(
+  providerId: string,
+  apiKey: string,
+  config: Config,
+): SpeechToTextClient | undefined {
+  const info = STT_PROVIDERS[providerId];
+  if (!info) {
+    return undefined;
+  }
+
+  const baseUrl = config.sttBaseUrl ?? info.defaultBaseUrl;
+  const model = config.sttModel ?? info.defaultModel;
+
+  return new OpenAICompatibleClient(apiKey, baseUrl, model);
+}
+
+function createLocalClient(config: Config): SpeechToTextClient {
+  if (!config.sttLocalCommand) {
+    throw new ValidationError('STT_LOCAL_COMMAND is required when STT_PROVIDER=local');
+  }
+  return new LocalWhisperClient(
+    config.sttLocalCommand,
+    config.sttLocalModel ?? 'base.en',
+    config.sttLocalModelDir,
+  );
+}
+
+function createCloudClient(config: Config): SpeechToTextClient | undefined {
+  const apiKey = config.sttApiKey ?? config.openaiApiKey;
+  if (!apiKey) {
+    return undefined;
+  }
+
+  const info = getProviderInfo(config.sttProvider);
+  if (!info) {
+    throw new ValidationError(`Unknown STT provider: ${config.sttProvider}`);
+  }
+
+  const baseUrl = config.sttBaseUrl ?? info.defaultBaseUrl;
+  const model = config.sttModel ?? info.defaultModel;
+
+  return new OpenAICompatibleClient(apiKey, baseUrl, model);
+}
+
+/**
+ * Probe all STT providers with the given API key.
+ * Returns the first provider that accepts the key, or undefined if none do.
+ * Caches the result for 24 hours.
+ * Only probes providers with no detectable key prefix.
+ */
+export async function probeSttProviders(
+  apiKey: string,
+): Promise<{ provider: string; baseUrl: string; model: string } | undefined> {
+  const providers = getProbeableProviders();
+
+  for (const info of providers) {
+    const isValid = await probeProvider(apiKey, info);
+    if (isValid) {
+      saveCachedProvider(apiKey, info.id);
+      return {
+        provider: info.id,
+        baseUrl: info.defaultBaseUrl,
+        model: info.defaultModel,
+      };
+    }
+  }
+
+  return undefined;
+}

--- a/packages/core/src/stt/factory.ts
+++ b/packages/core/src/stt/factory.ts
@@ -1,5 +1,7 @@
 import type { Config } from '@echos/shared';
 import { ValidationError } from '@echos/shared';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
 import type { SpeechToTextClient } from './index.js';
 import { OpenAICompatibleClient } from './openai-compatible-client.js';
 import { LocalWhisperClient } from './local-whisper-client.js';
@@ -14,6 +16,13 @@ import {
   saveCachedProvider,
   STT_PROVIDERS,
 } from './registry.js';
+
+/** Expand a leading `~` to the user's home directory. */
+function expandTilde(p: string): string {
+  if (p === '~') return homedir();
+  if (p.startsWith('~/')) return join(homedir(), p.slice(2));
+  return p;
+}
 
 export async function createSttClient(config: Config): Promise<SpeechToTextClient | undefined> {
   if (config.sttProvider === 'local') {
@@ -82,13 +91,13 @@ function createClientWithProvider(
 }
 
 function createLocalClient(config: Config): SpeechToTextClient {
-  if (!config.sttLocalCommand) {
-    throw new ValidationError('STT_LOCAL_COMMAND is required when STT_PROVIDER=local');
+  if (!config.sttLocalExecutable) {
+    throw new ValidationError('STT_LOCAL_EXECUTABLE is required when STT_PROVIDER=local');
   }
+  const modelPath = config.sttLocalModel ? expandTilde(config.sttLocalModel) : undefined;
   return new LocalWhisperClient(
-    config.sttLocalCommand,
-    config.sttLocalModel ?? 'base.en',
-    config.sttLocalModelDir,
+    expandTilde(config.sttLocalExecutable),
+    modelPath ?? 'base.en',
   );
 }
 

--- a/packages/core/src/stt/index.test.ts
+++ b/packages/core/src/stt/index.test.ts
@@ -22,7 +22,7 @@ import { join } from 'node:path';
 
 describe('createSttClient', () => {
   it('returns undefined when no STT config is provided', async () => {
-    const config = { sttProvider: 'auto' as const } as Config;
+    const config = { sttProvider: 'auto' as const } as unknown as Config;
     expect(await createSttClient(config)).toBeUndefined();
   });
 
@@ -30,7 +30,7 @@ describe('createSttClient', () => {
     const config = {
       sttProvider: 'auto' as const,
       sttApiKey: 'sk-test',
-    } as Config;
+    } as unknown as Config;
     const client = await createSttClient(config);
     expect(client).toBeInstanceOf(OpenAICompatibleClient);
   });
@@ -39,7 +39,7 @@ describe('createSttClient', () => {
     const config = {
       sttProvider: 'auto' as const,
       sttApiKey: 'gsk_test123',
-    } as Config;
+    } as unknown as Config;
     const client = await createSttClient(config);
     expect(client).toBeInstanceOf(OpenAICompatibleClient);
   });
@@ -48,7 +48,7 @@ describe('createSttClient', () => {
     const config = {
       sttProvider: 'auto' as const,
       sttApiKey: 'hf_test123',
-    } as Config;
+    } as unknown as Config;
     const client = await createSttClient(config);
     expect(client).toBeInstanceOf(OpenAICompatibleClient);
   });
@@ -57,7 +57,7 @@ describe('createSttClient', () => {
     const config = {
       sttProvider: 'auto' as const,
       sttApiKey: 'sk-or-test123',
-    } as Config;
+    } as unknown as Config;
     const client = await createSttClient(config);
     expect(client).toBeInstanceOf(OpenAICompatibleClient);
   });
@@ -66,7 +66,7 @@ describe('createSttClient', () => {
     const config = {
       sttProvider: 'groq' as const,
       sttApiKey: 'sk-some-key',
-    } as Config;
+    } as unknown as Config;
     const client = await createSttClient(config);
     expect(client).toBeInstanceOf(OpenAICompatibleClient);
   });
@@ -77,7 +77,7 @@ describe('createSttClient', () => {
       sttApiKey: 'gsk-test',
       sttBaseUrl: 'https://api.groq.com/openai/v1',
       sttModel: 'whisper-large-v3-turbo',
-    } as Config;
+    } as unknown as Config;
     const client = await createSttClient(config);
     expect(client).toBeInstanceOf(OpenAICompatibleClient);
   });
@@ -85,9 +85,9 @@ describe('createSttClient', () => {
   it('creates LocalWhisperClient when provider is local', async () => {
     const config = {
       sttProvider: 'local' as const,
-      sttLocalCommand: 'whisper-cpp',
+      sttLocalExecutable: 'whisper-cpp',
       sttLocalModel: 'base.en',
-    } as Config;
+    } as unknown as Config;
     const client = await createSttClient(config);
     expect(client).toBeInstanceOf(LocalWhisperClient);
   });
@@ -276,7 +276,7 @@ describe('STT provider probing', () => {
     globalThis.fetch = vi.fn().mockRejectedValue(new Error('network error'));
 
     const together = getProbeableProviders().find((p) => p.id === 'together')!;
-    const result = await probeProvider('some-key', together);
+    const result = await probeProvider('some-key', together!);
     expect(result).toBe(false);
 
     globalThis.fetch = originalFetch;
@@ -361,7 +361,7 @@ describe('transcribeWithRetry', () => {
   });
 
   it('retries on rate limit error', async () => {
-    const error = new RateLimitError('Rate limit exceeded');
+    const error = new RateLimitError(2000);
 
     const mockClient = {
       transcribe: vi
@@ -400,7 +400,7 @@ describe('transcribeWithRetry', () => {
   });
 
   it('throws after max retries exhausted', async () => {
-    const error = new RateLimitError('Rate limit exceeded');
+    const error = new RateLimitError(2000);
 
     const mockClient = {
       transcribe: vi.fn().mockRejectedValue(error),
@@ -477,11 +477,10 @@ describe('LocalWhisperClient', () => {
       expect(client).toBeDefined();
     });
 
-    it('creates client with custom model directory', () => {
+    it('creates client with custom model path', () => {
       const client = new LocalWhisperClient(
         'whisper-cli',
-        'medium',
-        '/custom/models',
+        '/custom/models/ggml-medium.bin',
       );
       expect(client).toBeDefined();
     });
@@ -518,12 +517,12 @@ describe('STT provider registry', () => {
     });
 
     it('has correct key prefix confidence levels', () => {
-      expect(STT_PROVIDERS.openai.keyPrefixConfidence).toBe('high');
-      expect(STT_PROVIDERS.groq.keyPrefixConfidence).toBe('high');
-      expect(STT_PROVIDERS.huggingface.keyPrefixConfidence).toBe('high');
-      expect(STT_PROVIDERS.openrouter.keyPrefixConfidence).toBe('high');
-      expect(STT_PROVIDERS.together.keyPrefixConfidence).toBe('none');
-      expect(STT_PROVIDERS.siliconflow.keyPrefixConfidence).toBe('none');
+      expect(STT_PROVIDERS['openai']!.keyPrefixConfidence).toBe('high');
+      expect(STT_PROVIDERS['groq']!.keyPrefixConfidence).toBe('high');
+      expect(STT_PROVIDERS['huggingface']!.keyPrefixConfidence).toBe('high');
+      expect(STT_PROVIDERS['openrouter']!.keyPrefixConfidence).toBe('high');
+      expect(STT_PROVIDERS['together']!.keyPrefixConfidence).toBe('none');
+      expect(STT_PROVIDERS['siliconflow']!.keyPrefixConfidence).toBe('none');
     });
   });
 
@@ -570,7 +569,7 @@ describe('STT integration scenarios', () => {
     const config = {
       sttProvider: 'auto' as const,
       sttApiKey: 'sk-proj-abc123',
-    } as Config;
+    } as unknown as Config;
 
     const client = await createSttClient(config);
     expect(client).toBeInstanceOf(OpenAICompatibleClient);
@@ -580,7 +579,7 @@ describe('STT integration scenarios', () => {
     const config = {
       sttProvider: 'auto' as const,
       sttApiKey: 'gsk_abc123',
-    } as Config;
+    } as unknown as Config;
 
     const client = await createSttClient(config);
     expect(client).toBeInstanceOf(OpenAICompatibleClient);
@@ -590,7 +589,7 @@ describe('STT integration scenarios', () => {
     const config = {
       sttProvider: 'together' as const,
       sttApiKey: 'some-opaque-key',
-    } as Config;
+    } as unknown as Config;
 
     const client = await createSttClient(config);
     expect(client).toBeInstanceOf(OpenAICompatibleClient);
@@ -599,9 +598,9 @@ describe('STT integration scenarios', () => {
   it('creates local whisper client', async () => {
     const config = {
       sttProvider: 'local' as const,
-      sttLocalCommand: 'whisper-cli',
+      sttLocalExecutable: 'whisper-cli',
       sttLocalModel: 'base.en',
-    } as Config;
+    } as unknown as Config;
 
     const client = await createSttClient(config);
     expect(client).toBeInstanceOf(LocalWhisperClient);
@@ -610,10 +609,10 @@ describe('STT integration scenarios', () => {
   it('throws error when local provider configured but no command', async () => {
     const config = {
       sttProvider: 'local' as const,
-    } as Config;
+    } as unknown as Config;
 
     await expect(createSttClient(config)).rejects.toThrow(
-      'STT_LOCAL_COMMAND is required when STT_PROVIDER=local',
+      'STT_LOCAL_EXECUTABLE is required when STT_PROVIDER=local',
     );
   });
 
@@ -621,7 +620,7 @@ describe('STT integration scenarios', () => {
     const config = {
       sttProvider: 'unknown-provider' as const,
       sttApiKey: 'some-key',
-    } as Config;
+    } as unknown as Config;
 
     await expect(createSttClient(config)).rejects.toThrow(
       'Unknown STT provider: unknown-provider',
@@ -632,7 +631,7 @@ describe('STT integration scenarios', () => {
     const config = {
       sttProvider: 'auto' as const,
       openaiApiKey: 'sk-fallback-key',
-    } as Config;
+    } as unknown as Config;
 
     const client = await createSttClient(config);
     expect(client).toBeInstanceOf(OpenAICompatibleClient);
@@ -677,7 +676,7 @@ describe('STT error handling', () => {
   it('handles missing API key', async () => {
     const config = {
       sttProvider: 'auto' as const,
-    } as Config;
+    } as unknown as Config;
 
     const client = await createSttClient(config);
     expect(client).toBeUndefined();
@@ -690,7 +689,7 @@ describe('STT error handling', () => {
     });
 
     const together = getProbeableProviders().find((p) => p.id === 'together')!;
-    const result = await probeProvider('invalid-key', together);
+    const result = await probeProvider('invalid-key', together!);
     expect(result).toBe(false);
   });
 });
@@ -702,8 +701,8 @@ describe('STT provider probing edge cases', () => {
       status: 401,
     });
 
-    const openai = STT_PROVIDERS.openai;
-    const result = await probeProvider('', openai);
+    const openai = STT_PROVIDERS['openai'];
+    const result = await probeProvider('', openai!);
     expect(result).toBe(false);
   });
 
@@ -711,7 +710,7 @@ describe('STT provider probing edge cases', () => {
     globalThis.fetch = vi.fn().mockRejectedValue(new Error('Invalid URL'));
 
     const together = getProbeableProviders().find((p) => p.id === 'together')!;
-    const result = await probeProvider('some-key', together);
+    const result = await probeProvider('some-key', together!);
     expect(result).toBe(false);
   });
 });

--- a/packages/core/src/stt/index.test.ts
+++ b/packages/core/src/stt/index.test.ts
@@ -1,0 +1,316 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createSttClient } from './factory.js';
+import { OpenAICompatibleClient } from './openai-compatible-client.js';
+import { LocalWhisperClient } from './local-whisper-client.js';
+import {
+  detectProviderFromKey,
+  detectProviderFromModel,
+  detectProviderFromUrl,
+  probeProvider,
+  loadCachedProvider,
+  saveCachedProvider,
+  getCloudProviders,
+  getProbeableProviders,
+} from './registry.js';
+import type { Config } from '@echos/shared';
+
+describe('createSttClient', () => {
+  it('returns undefined when no STT config is provided', async () => {
+    const config = { sttProvider: 'auto' as const } as Config;
+    expect(await createSttClient(config)).toBeUndefined();
+  });
+
+  it('creates OpenAICompatibleClient when sttApiKey is set (auto mode)', async () => {
+    const config = {
+      sttProvider: 'auto' as const,
+      sttApiKey: 'sk-test',
+    } as Config;
+    const client = await createSttClient(config);
+    expect(client).toBeInstanceOf(OpenAICompatibleClient);
+  });
+
+  it('auto-detects Groq from gsk_ key prefix', async () => {
+    const config = {
+      sttProvider: 'auto' as const,
+      sttApiKey: 'gsk_test123',
+    } as Config;
+    const client = await createSttClient(config);
+    expect(client).toBeInstanceOf(OpenAICompatibleClient);
+  });
+
+  it('auto-detects HuggingFace from hf_ key prefix', async () => {
+    const config = {
+      sttProvider: 'auto' as const,
+      sttApiKey: 'hf_test123',
+    } as Config;
+    const client = await createSttClient(config);
+    expect(client).toBeInstanceOf(OpenAICompatibleClient);
+  });
+
+  it('auto-detects OpenRouter from sk-or- key prefix', async () => {
+    const config = {
+      sttProvider: 'auto' as const,
+      sttApiKey: 'sk-or-test123',
+    } as Config;
+    const client = await createSttClient(config);
+    expect(client).toBeInstanceOf(OpenAICompatibleClient);
+  });
+
+  it('uses explicit provider when set', async () => {
+    const config = {
+      sttProvider: 'groq' as const,
+      sttApiKey: 'sk-some-key',
+    } as Config;
+    const client = await createSttClient(config);
+    expect(client).toBeInstanceOf(OpenAICompatibleClient);
+  });
+
+  it('uses custom baseUrl and model for explicit provider', async () => {
+    const config = {
+      sttProvider: 'groq' as const,
+      sttApiKey: 'gsk-test',
+      sttBaseUrl: 'https://api.groq.com/openai/v1',
+      sttModel: 'whisper-large-v3-turbo',
+    } as Config;
+    const client = await createSttClient(config);
+    expect(client).toBeInstanceOf(OpenAICompatibleClient);
+  });
+
+  it('creates LocalWhisperClient when provider is local', async () => {
+    const config = {
+      sttProvider: 'local' as const,
+      sttLocalCommand: 'whisper-cpp',
+      sttLocalModel: 'base.en',
+    } as Config;
+    const client = await createSttClient(config);
+    expect(client).toBeInstanceOf(LocalWhisperClient);
+  });
+});
+
+describe('OpenAICompatibleClient', () => {
+  it('sends correct FormData to the API', async () => {
+    const client = new OpenAICompatibleClient('sk-test', 'https://api.test.com/v1', 'test-model');
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve('Hello world'),
+    });
+
+    const result = await client.transcribe({
+      audioBuffer: Buffer.from('fake-audio'),
+      mimeType: 'audio/ogg',
+      language: 'en',
+    });
+
+    expect(result.text).toBe('Hello world');
+    expect(result.provider).toBe('test-model');
+    expect(result.duration).toBeDefined();
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      'https://api.test.com/v1/audio/transcriptions',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { Authorization: 'Bearer sk-test' },
+      }),
+    );
+
+    globalThis.fetch = originalFetch;
+  });
+
+  it('throws ExternalServiceError on non-429 errors', async () => {
+    const client = new OpenAICompatibleClient('sk-test', 'https://api.test.com/v1', 'test-model');
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve('Server error'),
+    });
+
+    await expect(
+      client.transcribe({
+        audioBuffer: Buffer.from('fake-audio'),
+        mimeType: 'audio/ogg',
+      }),
+    ).rejects.toThrow('Transcription failed (500): Server error');
+
+    globalThis.fetch = originalFetch;
+  });
+});
+
+describe('STT provider detection', () => {
+  describe('detectProviderFromKey', () => {
+    it('detects OpenAI from sk- prefix', () => {
+      expect(detectProviderFromKey('sk-abc123')).toBe('openai');
+    });
+
+    it('detects Groq from gsk_ prefix', () => {
+      expect(detectProviderFromKey('gsk_abc123')).toBe('groq');
+    });
+
+    it('detects HuggingFace from hf_ prefix', () => {
+      expect(detectProviderFromKey('hf_abc123')).toBe('huggingface');
+    });
+
+    it('detects OpenRouter from sk-or- prefix', () => {
+      expect(detectProviderFromKey('sk-or-abc123')).toBe('openrouter');
+    });
+
+    it('returns undefined for unknown prefix', () => {
+      expect(detectProviderFromKey('unknown-abc123')).toBeUndefined();
+    });
+
+    it('returns undefined for providers with no known prefix (together, siliconflow, deepinfra, fireworks)', () => {
+      expect(detectProviderFromKey('some-opaque-key')).toBeUndefined();
+    });
+  });
+
+  describe('detectProviderFromUrl', () => {
+    it('detects OpenAI from base URL', () => {
+      expect(detectProviderFromUrl('https://api.openai.com/v1')).toBe('openai');
+    });
+
+    it('detects Groq from base URL', () => {
+      expect(detectProviderFromUrl('https://api.groq.com/openai/v1')).toBe('groq');
+    });
+
+    it('detects Together AI from base URL', () => {
+      expect(detectProviderFromUrl('https://api.together.xyz/v1')).toBe('together');
+    });
+
+    it('detects DeepInfra from base URL', () => {
+      expect(detectProviderFromUrl('https://api.deepinfra.com/v1/openai')).toBe('deepinfra');
+    });
+
+    it('detects SiliconFlow from base URL', () => {
+      expect(detectProviderFromUrl('https://api.siliconflow.com/v1')).toBe('siliconflow');
+    });
+
+    it('detects Fireworks from base URL', () => {
+      expect(detectProviderFromUrl('https://api.fireworks.ai/inference/v1')).toBe('fireworks');
+    });
+
+    it('detects HuggingFace from base URL', () => {
+      expect(detectProviderFromUrl('https://router.huggingface.co/v1')).toBe('huggingface');
+    });
+
+    it('detects OpenRouter from base URL', () => {
+      expect(detectProviderFromUrl('https://openrouter.ai/api/v1')).toBe('openrouter');
+    });
+
+    it('returns undefined for unknown URL', () => {
+      expect(detectProviderFromUrl('https://unknown.example.com/v1')).toBeUndefined();
+    });
+  });
+
+  describe('detectProviderFromModel', () => {
+    it('detects Groq from whisper-large-v3', () => {
+      expect(detectProviderFromModel('whisper-large-v3')).toBe('groq');
+    });
+
+    it('detects Groq from whisper-large-v3-turbo', () => {
+      expect(detectProviderFromModel('whisper-large-v3-turbo')).toBe('groq');
+    });
+
+    it('detects SiliconFlow from SenseVoiceSmall', () => {
+      expect(detectProviderFromModel('FunAudioLLM/SenseVoiceSmall')).toBe('siliconflow');
+    });
+
+    it('returns undefined for unknown model', () => {
+      expect(detectProviderFromModel('unknown-model')).toBeUndefined();
+    });
+  });
+});
+
+describe('STT provider probing', () => {
+  it('only returns providers with no key prefix', () => {
+    const probeable = getProbeableProviders();
+    const ids = probeable.map((p) => p.id);
+    expect(ids).toContain('together');
+    expect(ids).toContain('siliconflow');
+    expect(ids).toContain('deepinfra');
+    expect(ids).toContain('fireworks');
+    expect(ids).not.toContain('openai');
+    expect(ids).not.toContain('groq');
+    expect(ids).not.toContain('huggingface');
+    expect(ids).not.toContain('openrouter');
+    expect(ids).not.toContain('local');
+  });
+
+  it('returns true when provider accepts the API key', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: [] }),
+    });
+
+    const together = getProbeableProviders().find((p) => p.id === 'together')!;
+    const result = await probeProvider('some-opaque-key', together);
+    expect(result).toBe(true);
+
+    globalThis.fetch = originalFetch;
+  });
+
+  it('returns false when provider rejects the API key', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+    });
+
+    const together = getProbeableProviders().find((p) => p.id === 'together')!;
+    const result = await probeProvider('some-invalid-key', together);
+    expect(result).toBe(false);
+
+    globalThis.fetch = originalFetch;
+  });
+
+  it('returns false on network error', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error('network error'));
+
+    const together = getProbeableProviders().find((p) => p.id === 'together')!;
+    const result = await probeProvider('some-key', together);
+    expect(result).toBe(false);
+
+    globalThis.fetch = originalFetch;
+  });
+
+  it('returns false on timeout', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi
+      .fn()
+      .mockImplementation((_url: string, opts: { signal?: AbortSignal }) => {
+        return new Promise<void>((_, reject) => {
+          const onAbort = () => reject(new Error('timeout'));
+          if (opts?.signal) {
+            if (opts.signal.aborted) {
+              reject(new Error('timeout'));
+            } else {
+              opts.signal.addEventListener('abort', onAbort, { once: true });
+            }
+          }
+        });
+      });
+
+    const together = getProbeableProviders().find((p) => p.id === 'together')!;
+    const result = await probeProvider('sk-some-key', together);
+    expect(result).toBe(false);
+
+    globalThis.fetch = originalFetch;
+  }, 10000);
+});
+
+describe('STT provider cache', () => {
+  it('saves and loads cached provider', () => {
+    const testKey = 'test-cache-key-abc123';
+    saveCachedProvider(testKey, 'groq');
+    const loaded = loadCachedProvider(testKey);
+    expect(loaded).toBe('groq');
+  });
+
+  it('returns undefined for uncached key', () => {
+    const loaded = loadCachedProvider('nonexistent-key-xyz');
+    expect(loaded).toBeUndefined();
+  });
+});

--- a/packages/core/src/stt/index.test.ts
+++ b/packages/core/src/stt/index.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { createSttClient } from './factory.js';
+import { createSttClient, probeSttProviders } from './factory.js';
+import { transcribeWithRetry } from './index.js';
 import { OpenAICompatibleClient } from './openai-compatible-client.js';
 import { LocalWhisperClient } from './local-whisper-client.js';
 import {
@@ -11,8 +12,13 @@ import {
   saveCachedProvider,
   getCloudProviders,
   getProbeableProviders,
+  getProviderInfo,
+  getProviderIds,
+  STT_PROVIDERS,
 } from './registry.js';
 import type { Config } from '@echos/shared';
+import { RateLimitError } from '@echos/shared';
+import { join } from 'node:path';
 
 describe('createSttClient', () => {
   it('returns undefined when no STT config is provided', async () => {
@@ -312,5 +318,425 @@ describe('STT provider cache', () => {
   it('returns undefined for uncached key', () => {
     const loaded = loadCachedProvider('nonexistent-key-xyz');
     expect(loaded).toBeUndefined();
+  });
+
+  it('expires old cache entries', () => {
+    const testKey = 'test-expired-key';
+    saveCachedProvider(testKey, 'openai');
+
+    // Manually set the cache entry to expired
+    const { readFileSync, writeFileSync } = require('node:fs');
+    const cachePath = join(
+      process.env['ECHOS_HOME'] || `${process.env['HOME']}/echos`,
+      'stt-provider-cache.json',
+    );
+    const cache = JSON.parse(readFileSync(cachePath, 'utf-8'));
+    const { createHash } = require('node:crypto');
+    const hash = createHash('sha256').update(testKey).digest('hex');
+    cache[hash].detectedAt = Date.now() - 25 * 60 * 60 * 1000; // 25 hours ago
+    writeFileSync(cachePath, JSON.stringify(cache));
+
+    const loaded = loadCachedProvider(testKey);
+    expect(loaded).toBeUndefined();
+  });
+});
+
+describe('transcribeWithRetry', () => {
+  it('succeeds on first attempt', async () => {
+    const mockClient = {
+      transcribe: vi.fn().mockResolvedValue({
+        text: 'Hello world',
+        provider: 'test',
+        duration: 100,
+      }),
+    };
+
+    const result = await transcribeWithRetry(mockClient as any, {
+      audioBuffer: Buffer.from('audio'),
+      mimeType: 'audio/wav',
+    });
+
+    expect(result.text).toBe('Hello world');
+    expect(mockClient.transcribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries on rate limit error', async () => {
+    const error = new RateLimitError('Rate limit exceeded');
+
+    const mockClient = {
+      transcribe: vi
+        .fn()
+        .mockRejectedValueOnce(error)
+        .mockRejectedValueOnce(error)
+        .mockResolvedValueOnce({
+          text: 'Success after retries',
+          provider: 'test',
+          duration: 300,
+        }),
+    };
+
+    const result = await transcribeWithRetry(mockClient as any, {
+      audioBuffer: Buffer.from('audio'),
+      mimeType: 'audio/wav',
+    });
+
+    expect(result.text).toBe('Success after retries');
+    expect(mockClient.transcribe).toHaveBeenCalledTimes(3);
+  });
+
+  it('throws on non-rate-limit errors without retry', async () => {
+    const mockClient = {
+      transcribe: vi.fn().mockRejectedValue(new Error('Network error')),
+    };
+
+    await expect(
+      transcribeWithRetry(mockClient as any, {
+        audioBuffer: Buffer.from('audio'),
+        mimeType: 'audio/wav',
+      }),
+    ).rejects.toThrow('Network error');
+
+    expect(mockClient.transcribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws after max retries exhausted', async () => {
+    const error = new RateLimitError('Rate limit exceeded');
+
+    const mockClient = {
+      transcribe: vi.fn().mockRejectedValue(error),
+    };
+
+    await expect(
+      transcribeWithRetry(
+        mockClient as any,
+        {
+          audioBuffer: Buffer.from('audio'),
+          mimeType: 'audio/wav',
+        },
+        2,
+      ),
+    ).rejects.toThrow('Rate limit exceeded');
+
+    expect(mockClient.transcribe).toHaveBeenCalledTimes(3); // initial + 2 retries
+  });
+});
+
+describe('LocalWhisperClient', () => {
+  describe('whisper type detection', () => {
+    it('detects whispercpp-python from wrapper script', () => {
+      const client = new LocalWhisperClient(
+        'python /path/to/whisper-cpp-wrapper.py',
+        'base.en',
+      );
+      expect(client).toBeInstanceOf(LocalWhisperClient);
+    });
+
+    it('detects openai-whisper from whisper command', () => {
+      const client = new LocalWhisperClient('whisper', 'base.en');
+      expect(client).toBeInstanceOf(LocalWhisperClient);
+    });
+
+    it('detects faster-whisper from module', () => {
+      const client = new LocalWhisperClient(
+        'python -m faster_whisper',
+        'base.en',
+      );
+      expect(client).toBeInstanceOf(LocalWhisperClient);
+    });
+
+    it('detects whisper-cpp from whisper-cli', () => {
+      const client = new LocalWhisperClient('whisper-cli', 'base.en');
+      expect(client).toBeInstanceOf(LocalWhisperClient);
+    });
+
+    it('detects generic for unknown commands', () => {
+      const client = new LocalWhisperClient('custom-stt', 'model');
+      expect(client).toBeInstanceOf(LocalWhisperClient);
+    });
+  });
+
+  describe('transcription', () => {
+    it('creates client with whisper-cli command', () => {
+      const client = new LocalWhisperClient('whisper-cli', 'base.en');
+      expect(client).toBeDefined();
+    });
+
+    it('creates client with Python wrapper command', () => {
+      const client = new LocalWhisperClient(
+        'python /path/to/whisper-cpp-wrapper.py',
+        'small.en',
+      );
+      expect(client).toBeDefined();
+    });
+
+    it('creates client with openai-whisper command', () => {
+      const client = new LocalWhisperClient(
+        'whisper --model base.en',
+        'base.en',
+      );
+      expect(client).toBeDefined();
+    });
+
+    it('creates client with custom model directory', () => {
+      const client = new LocalWhisperClient(
+        'whisper-cli',
+        'medium',
+        '/custom/models',
+      );
+      expect(client).toBeDefined();
+    });
+  });
+});
+
+describe('STT provider registry', () => {
+  describe('STT_PROVIDERS', () => {
+    it('contains all expected providers', () => {
+      const ids = Object.keys(STT_PROVIDERS);
+      expect(ids).toContain('openai');
+      expect(ids).toContain('groq');
+      expect(ids).toContain('together');
+      expect(ids).toContain('siliconflow');
+      expect(ids).toContain('deepinfra');
+      expect(ids).toContain('fireworks');
+      expect(ids).toContain('huggingface');
+      expect(ids).toContain('openrouter');
+      expect(ids).toContain('local');
+    });
+
+    it('has valid configuration for each provider', () => {
+      for (const [id, info] of Object.entries(STT_PROVIDERS)) {
+        expect(info.id).toBe(id);
+        expect(info.name).toBeDefined();
+        expect(info.defaultBaseUrl).toBeDefined();
+        expect(info.defaultModel).toBeDefined();
+        expect(info.docsUrl).toBeDefined();
+
+        if (info.keyPrefixConfidence !== 'none') {
+          expect(info.keyPrefixes.length).toBeGreaterThan(0);
+        }
+      }
+    });
+
+    it('has correct key prefix confidence levels', () => {
+      expect(STT_PROVIDERS.openai.keyPrefixConfidence).toBe('high');
+      expect(STT_PROVIDERS.groq.keyPrefixConfidence).toBe('high');
+      expect(STT_PROVIDERS.huggingface.keyPrefixConfidence).toBe('high');
+      expect(STT_PROVIDERS.openrouter.keyPrefixConfidence).toBe('high');
+      expect(STT_PROVIDERS.together.keyPrefixConfidence).toBe('none');
+      expect(STT_PROVIDERS.siliconflow.keyPrefixConfidence).toBe('none');
+    });
+  });
+
+  describe('getProviderInfo', () => {
+    it('returns provider info for valid ID', () => {
+      const info = getProviderInfo('openai');
+      expect(info).toBeDefined();
+      expect(info!.name).toBe('OpenAI');
+    });
+
+    it('returns undefined for invalid ID', () => {
+      const info = getProviderInfo('invalid');
+      expect(info).toBeUndefined();
+    });
+  });
+
+  describe('getProviderIds', () => {
+    it('returns all provider IDs', () => {
+      const ids = getProviderIds();
+      expect(ids.length).toBe(8); // 8 cloud providers + local = 9 total, but getProviderIds excludes local
+      expect(ids).toContain('openai');
+      expect(ids).not.toContain('local'); // getProviderIds excludes local
+    });
+  });
+
+  describe('getCloudProviders', () => {
+    it('returns all cloud providers', () => {
+      const cloud = getCloudProviders();
+      expect(cloud.length).toBe(8);
+      expect(cloud.find((p) => p.id === 'local')).toBeUndefined();
+    });
+  });
+
+  describe('longer prefix matching', () => {
+    it('matches sk-or- before sk-', () => {
+      expect(detectProviderFromKey('sk-or-v1-abc123')).toBe('openrouter');
+      expect(detectProviderFromKey('sk-or-v1-abc123')).not.toBe('openai');
+    });
+  });
+});
+
+describe('STT integration scenarios', () => {
+  it('creates OpenAI client with auto-detection', async () => {
+    const config = {
+      sttProvider: 'auto' as const,
+      sttApiKey: 'sk-proj-abc123',
+    } as Config;
+
+    const client = await createSttClient(config);
+    expect(client).toBeInstanceOf(OpenAICompatibleClient);
+  });
+
+  it('creates Groq client with auto-detection', async () => {
+    const config = {
+      sttProvider: 'auto' as const,
+      sttApiKey: 'gsk_abc123',
+    } as Config;
+
+    const client = await createSttClient(config);
+    expect(client).toBeInstanceOf(OpenAICompatibleClient);
+  });
+
+  it('creates Together AI client with explicit provider', async () => {
+    const config = {
+      sttProvider: 'together' as const,
+      sttApiKey: 'some-opaque-key',
+    } as Config;
+
+    const client = await createSttClient(config);
+    expect(client).toBeInstanceOf(OpenAICompatibleClient);
+  });
+
+  it('creates local whisper client', async () => {
+    const config = {
+      sttProvider: 'local' as const,
+      sttLocalCommand: 'whisper-cli',
+      sttLocalModel: 'base.en',
+    } as Config;
+
+    const client = await createSttClient(config);
+    expect(client).toBeInstanceOf(LocalWhisperClient);
+  });
+
+  it('throws error when local provider configured but no command', async () => {
+    const config = {
+      sttProvider: 'local' as const,
+    } as Config;
+
+    await expect(createSttClient(config)).rejects.toThrow(
+      'STT_LOCAL_COMMAND is required when STT_PROVIDER=local',
+    );
+  });
+
+  it('throws error for unknown explicit provider', async () => {
+    const config = {
+      sttProvider: 'unknown-provider' as const,
+      sttApiKey: 'some-key',
+    } as Config;
+
+    await expect(createSttClient(config)).rejects.toThrow(
+      'Unknown STT provider: unknown-provider',
+    );
+  });
+
+  it('uses fallback OPENAI_API_KEY when no STT_API_KEY', async () => {
+    const config = {
+      sttProvider: 'auto' as const,
+      openaiApiKey: 'sk-fallback-key',
+    } as Config;
+
+    const client = await createSttClient(config);
+    expect(client).toBeInstanceOf(OpenAICompatibleClient);
+  });
+});
+
+describe('STT error handling', () => {
+  it('handles transcription timeout', async () => {
+    const client = new OpenAICompatibleClient('sk-test', 'https://api.test.com/v1', 'test-model');
+
+    globalThis.fetch = vi.fn().mockImplementation(() => {
+      return new Promise((_, reject) => {
+        setTimeout(() => reject(new Error('timeout')), 100);
+      });
+    });
+
+    await expect(
+      client.transcribe({
+        audioBuffer: Buffer.from('audio'),
+        mimeType: 'audio/wav',
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('handles invalid audio format', async () => {
+    const client = new OpenAICompatibleClient('sk-test', 'https://api.test.com/v1', 'test-model');
+
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      text: () => Promise.resolve('Invalid audio format'),
+    });
+
+    await expect(
+      client.transcribe({
+        audioBuffer: Buffer.from('invalid-audio'),
+        mimeType: 'audio/xyz',
+      }),
+    ).rejects.toThrow('Transcription failed (400): Invalid audio format');
+  });
+
+  it('handles missing API key', async () => {
+    const config = {
+      sttProvider: 'auto' as const,
+    } as Config;
+
+    const client = await createSttClient(config);
+    expect(client).toBeUndefined();
+  });
+
+  it('handles provider probe failure', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+    });
+
+    const together = getProbeableProviders().find((p) => p.id === 'together')!;
+    const result = await probeProvider('invalid-key', together);
+    expect(result).toBe(false);
+  });
+});
+
+describe('STT provider probing edge cases', () => {
+  it('handles empty API key', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+    });
+
+    const openai = STT_PROVIDERS.openai;
+    const result = await probeProvider('', openai);
+    expect(result).toBe(false);
+  });
+
+  it('handles malformed URL in provider config', async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error('Invalid URL'));
+
+    const together = getProbeableProviders().find((p) => p.id === 'together')!;
+    const result = await probeProvider('some-key', together);
+    expect(result).toBe(false);
+  });
+});
+
+describe('probeSttProviders integration', () => {
+  it('returns first successful provider', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: [] }),
+    });
+
+    const result = await probeSttProviders('valid-api-key');
+    expect(result).toBeDefined();
+    expect(result!.provider).toBeDefined();
+    expect(result!.baseUrl).toBeDefined();
+    expect(result!.model).toBeDefined();
+  });
+
+  it('returns undefined when no providers accept the key', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+    });
+
+    const result = await probeSttProviders('invalid-api-key');
+    expect(result).toBeUndefined();
   });
 });

--- a/packages/core/src/stt/index.ts
+++ b/packages/core/src/stt/index.ts
@@ -1,0 +1,56 @@
+import { RateLimitError } from '@echos/shared';
+
+export interface TranscribeOptions {
+  audioBuffer: Buffer;
+  mimeType: string;
+  language?: string;
+}
+
+export interface TranscribeResult {
+  text: string;
+  provider: string;
+  duration?: number;
+}
+
+export interface SpeechToTextClient {
+  transcribe(options: TranscribeOptions): Promise<TranscribeResult>;
+}
+
+export async function transcribeWithRetry(
+  client: SpeechToTextClient,
+  options: TranscribeOptions,
+  maxRetries = 2,
+): Promise<TranscribeResult> {
+  for (let i = 0; i <= maxRetries; i++) {
+    try {
+      return await client.transcribe(options);
+    } catch (err) {
+      const isRateLimit = err instanceof RateLimitError;
+      if (isRateLimit && i < maxRetries) {
+        const delay = Math.pow(2, i) * 1000;
+        await new Promise((r) => setTimeout(r, delay));
+        continue;
+      }
+      throw err;
+    }
+  }
+  throw new Error('unreachable');
+}
+
+export { createSttClient, probeSttProviders } from './factory.js';
+export { OpenAICompatibleClient } from './openai-compatible-client.js';
+export { LocalWhisperClient } from './local-whisper-client.js';
+export {
+  STT_PROVIDERS,
+  detectProviderFromKey,
+  detectProviderFromModel,
+  detectProviderFromUrl,
+  getProviderInfo,
+  getProviderIds,
+  getCloudProviders,
+  getProbeableProviders,
+  probeProvider,
+  loadCachedProvider,
+  saveCachedProvider,
+} from './registry.js';
+export type { SttProviderInfo } from './registry.js';

--- a/packages/core/src/stt/local-whisper-client.ts
+++ b/packages/core/src/stt/local-whisper-client.ts
@@ -1,0 +1,112 @@
+import { spawn } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { readFile, unlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { SpeechToTextClient, TranscribeOptions, TranscribeResult } from './index.js';
+
+function spawnAsync(
+  command: string,
+  args: string[],
+  shell = false,
+): Promise<{ stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { stdio: ['pipe', 'pipe', 'pipe'], shell });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (d) => {
+      stdout += d.toString();
+    });
+    child.stderr.on('data', (d) => {
+      stderr += d.toString();
+    });
+    child.on('close', (code) => {
+      if (code === 0) resolve({ stdout, stderr });
+      else reject(new Error(`${command} exited with code ${code}: ${stderr}`));
+    });
+    child.on('error', reject);
+  });
+}
+
+export class LocalWhisperClient implements SpeechToTextClient {
+  constructor(
+    private command: string,
+    private model: string,
+    private modelDir?: string,
+  ) {}
+
+  async transcribe({
+    audioBuffer,
+    mimeType,
+    language,
+  }: TranscribeOptions): Promise<TranscribeResult> {
+    const start = Date.now();
+    const baseName = `echos-stt-${randomUUID()}`;
+    const tmpPath = join(tmpdir(), baseName);
+
+    try {
+      let audioPath: string;
+
+      if (mimeType === 'audio/wav' || mimeType === 'audio/x-wav') {
+        audioPath = `${tmpPath}.wav`;
+        await writeFile(audioPath, audioBuffer);
+      } else {
+        const inputPath = `${tmpPath}.input`;
+        await writeFile(inputPath, audioBuffer);
+        audioPath = `${tmpPath}.wav`;
+        await spawnAsync('ffmpeg', [
+          '-i',
+          inputPath,
+          '-ar',
+          '16000',
+          '-ac',
+          '1',
+          '-f',
+          'wav',
+          audioPath,
+        ]);
+        await unlink(inputPath).catch(() => undefined);
+      }
+
+      const text = await this.runTranscription(audioPath, language);
+
+      return { text: text.trim(), provider: `local/${this.model}`, duration: Date.now() - start };
+    } finally {
+      const files = [`${tmpPath}.input`, `${tmpPath}.wav`, `${tmpPath}.wav.txt`];
+      for (const f of files) {
+        try {
+          await unlink(f);
+        } catch {
+          /* ignore */
+        }
+      }
+    }
+  }
+
+  private async runTranscription(audioPath: string, language?: string): Promise<string> {
+    const isPythonScript = this.command.endsWith('.py') || this.command.includes('python');
+
+    if (isPythonScript) {
+      const parts = this.command.trim().split(/\s+/);
+      const cmd = parts[0]!;
+      const scriptArgs = parts.slice(1);
+      const args = [...scriptArgs, '-f', audioPath];
+      if (this.model) args.push('-m', this.model);
+      if (language) args.push('-l', language);
+      if (this.modelDir) {
+        args.push('-o', this.modelDir);
+      }
+      const { stdout } = await spawnAsync(cmd, args);
+      return stdout.trim();
+    }
+
+    const modelPath = `${this.modelDir ?? '/usr/local/share/whisper.cpp/models'}/${this.model}.bin`;
+    const args = ['-m', modelPath, '-f', audioPath, '-otxt'];
+    if (language) args.push('-l', language);
+
+    await spawnAsync(this.command, args);
+
+    const txtPath = `${audioPath}.txt`;
+    return (await readFile(txtPath, 'utf-8')).trim();
+  }
+}

--- a/packages/core/src/stt/local-whisper-client.ts
+++ b/packages/core/src/stt/local-whisper-client.ts
@@ -47,12 +47,10 @@ export class LocalWhisperClient implements SpeechToTextClient {
   private whisperType: 'whisper-cpp' | 'whispercpp-python' | 'openai-whisper' | 'faster-whisper' | 'generic';
 
   constructor(
-    command: string,
-    private model: string,
-    private modelDir?: string,
+    private command: string,
+    private model: string, // Full path to model file, or model name for Python packages
   ) {
     this.whisperType = this.detectWhisperType(command);
-    this.command = command;
   }
 
   private detectWhisperType(command: string): LocalWhisperClient['whisperType'] {
@@ -165,7 +163,6 @@ export class LocalWhisperClient implements SpeechToTextClient {
     const args = [...scriptArgs, '-f', audioPath];
     if (this.model) args.push('-m', this.model);
     if (language) args.push('-l', language);
-    if (this.modelDir) args.push('-o', this.modelDir);
     const { stdout } = await spawnAsync(cmd, args);
     return stdout.trim();
   }
@@ -229,8 +226,7 @@ export class LocalWhisperClient implements SpeechToTextClient {
    * Command: whisper-cli or /path/to/main
    */
   private async runWhisperCpp(audioPath: string, language?: string): Promise<string> {
-    const modelPath = `${this.modelDir ?? '/usr/local/share/whisper.cpp/models'}/${this.model}.bin`;
-    const args = ['-m', modelPath, '-f', audioPath, '-otxt'];
+    const args = ['-m', this.model, '-f', audioPath, '-otxt'];
     if (language) args.push('-l', language);
 
     await spawnAsync(this.command, args);

--- a/packages/core/src/stt/local-whisper-client.ts
+++ b/packages/core/src/stt/local-whisper-client.ts
@@ -28,12 +28,67 @@ function spawnAsync(
   });
 }
 
+/**
+ * Local Whisper client for offline speech-to-text.
+ *
+ * Supports multiple Whisper implementations:
+ * - whisper.cpp CLI (whisper-cli, main)
+ * - whispercpp Python package (via wrapper script)
+ * - openai-whisper Python package (official OpenAI Whisper)
+ * - faster-whisper Python package (CTranslate2-based)
+ *
+ * Configuration examples:
+ * - whisper.cpp: STT_LOCAL_COMMAND=whisper-cli
+ * - whispercpp:  STT_LOCAL_COMMAND="python /path/to/whisper-cpp-wrapper.py"
+ * - openai-whisper: STT_LOCAL_COMMAND="whisper --model base.en --output_format txt"
+ * - faster-whisper: STT_LOCAL_COMMAND="python -m faster_whisper --model base.en"
+ */
 export class LocalWhisperClient implements SpeechToTextClient {
+  private whisperType: 'whisper-cpp' | 'whispercpp-python' | 'openai-whisper' | 'faster-whisper' | 'generic';
+
   constructor(
-    private command: string,
+    command: string,
     private model: string,
     private modelDir?: string,
-  ) {}
+  ) {
+    this.whisperType = this.detectWhisperType(command);
+    this.command = command;
+  }
+
+  private detectWhisperType(command: string): LocalWhisperClient['whisperType'] {
+    const normalized = command.toLowerCase().trim();
+
+    // Check for Python-based implementations
+    if (normalized.includes('python') || normalized.endsWith('.py')) {
+      // Check for whispercpp Python package wrapper
+      if (normalized.includes('whisper-cpp-wrapper') || normalized.includes('whispercpp')) {
+        return 'whispercpp-python';
+      }
+      // Check for faster-whisper
+      if (normalized.includes('faster_whisper') || normalized.includes('faster-whisper')) {
+        return 'faster-whisper';
+      }
+      // Generic Python command
+      return 'generic';
+    }
+
+    // Check for openai-whisper CLI (official OpenAI Whisper package)
+    if (normalized.includes('whisper ') || normalized === 'whisper') {
+      return 'openai-whisper';
+    }
+
+    // Check for whisper.cpp CLI
+    if (
+      normalized.includes('whisper-cli') ||
+      normalized.includes('main') ||
+      normalized.includes('whisper.cpp')
+    ) {
+      return 'whisper-cpp';
+    }
+
+    // Default to generic
+    return 'generic';
+  }
 
   async transcribe({
     audioBuffer,
@@ -84,22 +139,96 @@ export class LocalWhisperClient implements SpeechToTextClient {
   }
 
   private async runTranscription(audioPath: string, language?: string): Promise<string> {
-    const isPythonScript = this.command.endsWith('.py') || this.command.includes('python');
-
-    if (isPythonScript) {
-      const parts = this.command.trim().split(/\s+/);
-      const cmd = parts[0]!;
-      const scriptArgs = parts.slice(1);
-      const args = [...scriptArgs, '-f', audioPath];
-      if (this.model) args.push('-m', this.model);
-      if (language) args.push('-l', language);
-      if (this.modelDir) {
-        args.push('-o', this.modelDir);
-      }
-      const { stdout } = await spawnAsync(cmd, args);
-      return stdout.trim();
+    switch (this.whisperType) {
+      case 'whispercpp-python':
+        return this.runWhisperCppPython(audioPath, language);
+      case 'openai-whisper':
+        return this.runOpenAiWhisper(audioPath, language);
+      case 'faster-whisper':
+        return this.runFasterWhisper(audioPath, language);
+      case 'whisper-cpp':
+        return this.runWhisperCpp(audioPath, language);
+      case 'generic':
+      default:
+        return this.runGenericCommand(audioPath, language);
     }
+  }
 
+  /**
+   * Run whispercpp Python package via wrapper script.
+   * Command: python /path/to/whisper-cpp-wrapper.py
+   */
+  private async runWhisperCppPython(audioPath: string, language?: string): Promise<string> {
+    const parts = this.command.trim().split(/\s+/);
+    const cmd = parts[0]!;
+    const scriptArgs = parts.slice(1);
+    const args = [...scriptArgs, '-f', audioPath];
+    if (this.model) args.push('-m', this.model);
+    if (language) args.push('-l', language);
+    if (this.modelDir) args.push('-o', this.modelDir);
+    const { stdout } = await spawnAsync(cmd, args);
+    return stdout.trim();
+  }
+
+  /**
+   * Run official OpenAI Whisper Python package.
+   * Command: whisper --model base.en --output_format txt
+   */
+  private async runOpenAiWhisper(audioPath: string, language?: string): Promise<string> {
+    const parts = this.command.trim().split(/\s+/);
+    const cmd = parts[0]!;
+    const baseArgs = parts.slice(1);
+
+    const args = [...baseArgs];
+    // Add model if not already specified
+    if (!baseArgs.some((a) => a.startsWith('--model') || a.startsWith('-m'))) {
+      args.push('--model', this.model);
+    }
+    // Ensure output format is text
+    if (!baseArgs.includes('--output_format')) {
+      args.push('--output_format', 'txt');
+    }
+    // Add language if specified
+    if (language && !baseArgs.includes('--language')) {
+      args.push('--language', language);
+    }
+    // Add audio file
+    args.push(audioPath);
+
+    const { stdout } = await spawnAsync(cmd, args);
+    return stdout.trim();
+  }
+
+  /**
+   * Run faster-whisper Python package.
+   * Command: python -m faster_whisper --model base.en
+   */
+  private async runFasterWhisper(audioPath: string, language?: string): Promise<string> {
+    const parts = this.command.trim().split(/\s+/);
+    const cmd = parts[0]!;
+    const baseArgs = parts.slice(1);
+
+    const args = [...baseArgs];
+    // Add model if not already specified
+    if (!baseArgs.some((a) => a.startsWith('--model') || a.startsWith('-m'))) {
+      args.push('--model', this.model);
+    }
+    // Add language if specified
+    if (language && !baseArgs.includes('--language')) {
+      args.push('--language', language);
+    }
+    // Add audio file
+    args.push(audioPath);
+
+    const { stdout } = await spawnAsync(cmd, args);
+    return stdout.trim();
+  }
+
+  /**
+   * Run whisper.cpp CLI (whisper-cli, main).
+   * Command: whisper-cli or /path/to/main
+   */
+  private async runWhisperCpp(audioPath: string, language?: string): Promise<string> {
     const modelPath = `${this.modelDir ?? '/usr/local/share/whisper.cpp/models'}/${this.model}.bin`;
     const args = ['-m', modelPath, '-f', audioPath, '-otxt'];
     if (language) args.push('-l', language);
@@ -108,5 +237,21 @@ export class LocalWhisperClient implements SpeechToTextClient {
 
     const txtPath = `${audioPath}.txt`;
     return (await readFile(txtPath, 'utf-8')).trim();
+  }
+
+  /**
+   * Run a generic command with the audio file path.
+   * The command should output transcription to stdout.
+   */
+  private async runGenericCommand(audioPath: string, language?: string): Promise<string> {
+    const parts = this.command.trim().split(/\s+/);
+    const cmd = parts[0]!;
+    const baseArgs = parts.slice(1);
+
+    const args = [...baseArgs, audioPath];
+    if (language) args.push('--language', language);
+
+    const { stdout } = await spawnAsync(cmd, args);
+    return stdout.trim();
   }
 }

--- a/packages/core/src/stt/openai-compatible-client.ts
+++ b/packages/core/src/stt/openai-compatible-client.ts
@@ -1,0 +1,41 @@
+import { ExternalServiceError, RateLimitError } from '@echos/shared';
+import type { SpeechToTextClient, TranscribeOptions, TranscribeResult } from './index.js';
+
+export class OpenAICompatibleClient implements SpeechToTextClient {
+  constructor(
+    private apiKey: string,
+    private baseUrl: string,
+    private model: string,
+  ) {}
+
+  async transcribe({
+    audioBuffer,
+    mimeType,
+    language,
+  }: TranscribeOptions): Promise<TranscribeResult> {
+    const start = Date.now();
+    const form = new FormData();
+    const uint8Array = new Uint8Array(audioBuffer);
+    form.append('file', new Blob([uint8Array], { type: mimeType }), 'audio.ogg');
+    form.append('model', this.model);
+    if (language) form.append('language', language);
+    form.append('response_format', 'text');
+
+    const res = await fetch(`${this.baseUrl}/audio/transcriptions`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${this.apiKey}` },
+      body: form,
+    });
+
+    if (!res.ok) {
+      const body = await res.text();
+      if (res.status === 429) {
+        throw new RateLimitError(5000);
+      }
+      throw new ExternalServiceError('STT', `Transcription failed (${res.status}): ${body}`, true);
+    }
+
+    const text = await res.text();
+    return { text: text.trim(), provider: this.model, duration: Date.now() - start };
+  }
+}

--- a/packages/core/src/stt/registry.ts
+++ b/packages/core/src/stt/registry.ts
@@ -1,0 +1,301 @@
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { createHash } from 'node:crypto';
+
+/**
+ * STT Provider Registry
+ *
+ * Maps known Whisper-compatible providers to their configuration.
+ * Supports auto-detection via API key prefix, base URL, and model name.
+ *
+ * Key prefix confidence levels:
+ *   HIGH  - Confirmed from official docs or multiple independent sources
+ *   LOW   - Community-reported, not independently verified
+ *   NONE  - No known prefix pattern (provider uses opaque keys)
+ */
+
+export interface SttProviderInfo {
+  /** Canonical provider ID */
+  id: string;
+  /** Human-readable name */
+  name: string;
+  /** Known API key prefixes for auto-detection (empty means no reliable prefix) */
+  keyPrefixes: string[];
+  /** Confidence level of key prefix detection: HIGH, LOW, or NONE */
+  keyPrefixConfidence: 'high' | 'low' | 'none';
+  /** Default base URL for the provider */
+  defaultBaseUrl: string;
+  /** Default model name for the provider */
+  defaultModel: string;
+  /** Known model aliases that map to this provider */
+  modelHints: string[];
+  /** Documentation URL */
+  docsUrl: string;
+}
+
+export const STT_PROVIDERS: Record<string, SttProviderInfo> = {
+  openai: {
+    id: 'openai',
+    name: 'OpenAI',
+    keyPrefixes: ['sk-'],
+    keyPrefixConfidence: 'high',
+    defaultBaseUrl: 'https://api.openai.com/v1',
+    defaultModel: 'whisper-1',
+    modelHints: ['whisper-1'],
+    docsUrl: 'https://platform.openai.com/docs/guides/speech-to-text',
+  },
+  groq: {
+    id: 'groq',
+    name: 'Groq',
+    keyPrefixes: ['gsk_'],
+    keyPrefixConfidence: 'high',
+    defaultBaseUrl: 'https://api.groq.com/openai/v1',
+    defaultModel: 'whisper-large-v3-turbo',
+    modelHints: ['whisper-large-v3', 'whisper-large-v3-turbo'],
+    docsUrl: 'https://console.groq.com/docs/models',
+  },
+  together: {
+    id: 'together',
+    name: 'Together AI',
+    keyPrefixes: [],
+    keyPrefixConfidence: 'none',
+    defaultBaseUrl: 'https://api.together.xyz/v1',
+    defaultModel: 'openai/whisper-large-v3-turbo',
+    modelHints: ['whisper-large-v3', 'whisper-large-v3-turbo', 'openai/whisper-large-v3-turbo'],
+    docsUrl: 'https://docs.together.ai/docs/audio-overview',
+  },
+  siliconflow: {
+    id: 'siliconflow',
+    name: 'SiliconFlow',
+    keyPrefixes: [],
+    keyPrefixConfidence: 'none',
+    defaultBaseUrl: 'https://api.siliconflow.com/v1',
+    defaultModel: 'FunAudioLLM/SenseVoiceSmall',
+    modelHints: ['SenseVoiceSmall', 'FunAudioLLM/SenseVoiceSmall'],
+    docsUrl: 'https://docs.siliconflow.cn/en/docs/audio/audio',
+  },
+  deepinfra: {
+    id: 'deepinfra',
+    name: 'DeepInfra',
+    keyPrefixes: [],
+    keyPrefixConfidence: 'none',
+    defaultBaseUrl: 'https://api.deepinfra.com/v1/openai',
+    defaultModel: 'openai/whisper-large-v3-turbo',
+    modelHints: ['whisper-large-v3', 'whisper-large-v3-turbo', 'openai/whisper-large-v3-turbo'],
+    docsUrl: 'https://deepinfra.com/openai/whisper-large-v3-turbo',
+  },
+  fireworks: {
+    id: 'fireworks',
+    name: 'Fireworks AI',
+    keyPrefixes: [],
+    keyPrefixConfidence: 'none',
+    defaultBaseUrl: 'https://api.fireworks.ai/inference/v1',
+    defaultModel: 'whisper-large-v3-turbo',
+    modelHints: ['whisper-large-v3', 'whisper-large-v3-turbo'],
+    docsUrl: 'https://docs.fireworks.ai/models/audio',
+  },
+  huggingface: {
+    id: 'huggingface',
+    name: 'Hugging Face',
+    keyPrefixes: ['hf_'],
+    keyPrefixConfidence: 'high',
+    defaultBaseUrl: 'https://router.huggingface.co/v1',
+    defaultModel: 'openai/whisper-large-v3-turbo',
+    modelHints: ['whisper-large-v3', 'whisper-large-v3-turbo', 'openai/whisper-large-v3-turbo'],
+    docsUrl: 'https://huggingface.co/docs/inference-providers',
+  },
+  openrouter: {
+    id: 'openrouter',
+    name: 'OpenRouter',
+    keyPrefixes: ['sk-or-'],
+    keyPrefixConfidence: 'high',
+    defaultBaseUrl: 'https://openrouter.ai/api/v1',
+    defaultModel: 'openai/whisper-large-v3-turbo',
+    modelHints: ['whisper-large-v3', 'whisper-large-v3-turbo', 'openai/whisper-large-v3-turbo'],
+    docsUrl: 'https://openrouter.ai/models?modality=text%3Aaudio',
+  },
+  local: {
+    id: 'local',
+    name: 'Local (whisper.cpp)',
+    keyPrefixes: [],
+    keyPrefixConfidence: 'none',
+    defaultBaseUrl: '',
+    defaultModel: 'base.en',
+    modelHints: [],
+    docsUrl: 'https://github.com/ggerganov/whisper.cpp',
+  },
+};
+
+/**
+ * Auto-detect STT provider from API key prefix.
+ * Returns the provider ID or undefined if no match.
+ * Checks longer prefixes first to avoid false matches
+ * (e.g., `sk-or-` should match openrouter before `sk-` matches openai).
+ */
+export function detectProviderFromKey(apiKey: string): string | undefined {
+  const matches: { prefix: string; id: string }[] = [];
+  for (const [id, info] of Object.entries(STT_PROVIDERS)) {
+    if (id === 'local') continue;
+    for (const prefix of info.keyPrefixes) {
+      if (apiKey.startsWith(prefix)) {
+        matches.push({ prefix, id });
+      }
+    }
+  }
+  if (matches.length === 0) return undefined;
+  matches.sort((a, b) => b.prefix.length - a.prefix.length);
+  return matches[0]!.id;
+}
+
+/**
+ * Auto-detect STT provider from base URL.
+ * Returns the provider ID or undefined if no match.
+ */
+export function detectProviderFromUrl(baseUrl: string): string | undefined {
+  const normalized = baseUrl.replace(/\/+$/, '');
+  for (const [id, info] of Object.entries(STT_PROVIDERS)) {
+    if (id === 'local') continue;
+    const defaultUrl = info.defaultBaseUrl.replace(/\/+$/, '');
+    if (normalized === defaultUrl) {
+      return id;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Auto-detect STT provider from model name.
+ * Returns the provider ID or undefined if no match.
+ */
+export function detectProviderFromModel(model: string): string | undefined {
+  for (const [id, info] of Object.entries(STT_PROVIDERS)) {
+    if (id === 'local') continue;
+    for (const hint of info.modelHints) {
+      if (model.includes(hint)) {
+        return id;
+      }
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Get provider info by ID.
+ */
+export function getProviderInfo(id: string): SttProviderInfo | undefined {
+  return STT_PROVIDERS[id];
+}
+
+/**
+ * Get all non-local provider IDs.
+ */
+export function getProviderIds(): string[] {
+  return Object.keys(STT_PROVIDERS).filter((id) => id !== 'local');
+}
+
+/**
+ * Get all cloud (non-local) provider info entries.
+ */
+export function getCloudProviders(): SttProviderInfo[] {
+  return Object.values(STT_PROVIDERS).filter((p) => p.id !== 'local');
+}
+
+/**
+ * Get providers that have no detectable key prefix.
+ * These are the only candidates for API key probing.
+ */
+export function getProbeableProviders(): SttProviderInfo[] {
+  return Object.values(STT_PROVIDERS).filter(
+    (p) => p.id !== 'local' && p.keyPrefixConfidence === 'none',
+  );
+}
+
+/**
+ * Probe a provider with an API key by hitting the /models endpoint.
+ * Returns true if the key is valid (200 response).
+ */
+export async function probeProvider(apiKey: string, provider: SttProviderInfo): Promise<boolean> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 5000);
+
+  try {
+    const res = await fetch(`${provider.defaultBaseUrl}/models`, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+      signal: controller.signal,
+    });
+
+    return res.ok;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+/**
+ * Cache entry for a detected provider.
+ */
+interface ProviderCacheEntry {
+  provider: string;
+  detectedAt: number;
+  ttlMs: number;
+}
+
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+function getCachePath(): string {
+  const home = process.env['ECHOS_HOME'] ?? `${process.env['HOME'] ?? ''}/echos`;
+  return `${home}/stt-provider-cache.json`;
+}
+
+function getCache(): Record<string, ProviderCacheEntry> {
+  try {
+    return JSON.parse(readFileSync(getCachePath(), 'utf-8'));
+  } catch {
+    return {};
+  }
+}
+
+function saveCache(cache: Record<string, ProviderCacheEntry>): void {
+  try {
+    mkdirSync(dirname(getCachePath()), { recursive: true });
+    writeFileSync(getCachePath(), JSON.stringify(cache, null, 2));
+  } catch {
+    // ignore write errors
+  }
+}
+
+function hashApiKey(apiKey: string): string {
+  return createHash('sha256').update(apiKey).digest('hex');
+}
+
+/**
+ * Load a cached provider for an API key.
+ * Returns the provider ID if found and not expired, undefined otherwise.
+ */
+export function loadCachedProvider(apiKey: string): string | undefined {
+  const cache = getCache();
+  const entry = cache[hashApiKey(apiKey)];
+  if (!entry) return undefined;
+
+  if (Date.now() - entry.detectedAt > entry.ttlMs) {
+    delete cache[hashApiKey(apiKey)];
+    saveCache(cache);
+    return undefined;
+  }
+
+  return entry.provider;
+}
+
+/**
+ * Save a detected provider to cache.
+ */
+export function saveCachedProvider(apiKey: string, provider: string): void {
+  const cache = getCache();
+  cache[hashApiKey(apiKey)] = {
+    provider,
+    detectedAt: Date.now(),
+    ttlMs: CACHE_TTL_MS,
+  };
+  saveCache(cache);
+}

--- a/packages/scheduler/src/workers/content.ts
+++ b/packages/scheduler/src/workers/content.ts
@@ -3,7 +3,12 @@ import type { Logger } from 'pino';
 import type { JobData } from '../queue.js';
 import { processArticle } from '@echos/plugin-article';
 import { processYoutube } from '@echos/plugin-youtube';
-import type { SqliteStorage, MarkdownStorage, VectorStorage } from '@echos/core';
+import type {
+  SqliteStorage,
+  MarkdownStorage,
+  VectorStorage,
+  SpeechToTextClient,
+} from '@echos/core';
 import type { NoteMetadata } from '@echos/shared';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -13,7 +18,7 @@ export interface ContentWorkerDeps {
   vectorDb: VectorStorage;
   generateEmbedding: (text: string) => Promise<number[]>;
   logger: Logger;
-  openaiApiKey?: string;
+  sttClient?: SpeechToTextClient;
   whisperLanguage?: string;
   notifyUser?: (chatId: number, message: string) => Promise<void>;
 }
@@ -28,7 +33,7 @@ export function createContentProcessor(deps: ContentWorkerDeps) {
     const processed =
       type === 'process_article'
         ? await processArticle(url, deps.logger)
-        : await processYoutube(url, deps.logger, deps.openaiApiKey, undefined, deps.whisperLanguage);
+        : await processYoutube(url, deps.logger, deps.sttClient, undefined, deps.whisperLanguage);
 
     const now = new Date().toISOString();
     const id = uuidv4();

--- a/packages/shared/src/config/index.ts
+++ b/packages/shared/src/config/index.ts
@@ -66,9 +66,8 @@ export const configSchema = z
     sttApiKey: z.string().optional(),
     sttBaseUrl: z.string().url().optional(),
     sttModel: z.string().optional(),
-    sttLocalCommand: z.string().optional(),
-    sttLocalModel: z.string().default('base.en'),
-    sttLocalModelDir: z.string().optional(),
+    sttLocalExecutable: z.string().optional(),
+    sttLocalModel: z.string().optional(), // Full path to model file
 
     // Multi-provider LLM support
     llmApiKey: z.string().min(1).optional(),
@@ -183,9 +182,8 @@ export function loadConfig(env: Record<string, string | undefined> = process.env
     sttApiKey: env['STT_API_KEY'],
     sttBaseUrl: env['STT_BASE_URL'],
     sttModel: env['STT_MODEL'],
-    sttLocalCommand: env['STT_LOCAL_COMMAND'],
+    sttLocalExecutable: env['STT_LOCAL_EXECUTABLE'],
     sttLocalModel: env['STT_LOCAL_MODEL'],
-    sttLocalModelDir: env['STT_LOCAL_MODEL_DIR'],
     llmApiKey: env['LLM_API_KEY'],
     llmBaseUrl: env['LLM_BASE_URL'],
     redisUrl: env['REDIS_URL'],

--- a/packages/shared/src/config/index.ts
+++ b/packages/shared/src/config/index.ts
@@ -25,118 +25,142 @@ export const ECHOS_HOME = resolveEchosHome(process.env);
 
 export const configSchema = z
   .object({
-  // Required
-  telegramBotToken: z.string().optional(), // Required only when enableTelegram=true (checked at runtime)
-  allowedUserIds: commaSeparatedNumbers,
-  anthropicApiKey: z.string().min(1).optional(),
+    // Required
+    telegramBotToken: z.string().optional(), // Required only when enableTelegram=true (checked at runtime)
+    allowedUserIds: commaSeparatedNumbers,
+    anthropicApiKey: z.string().min(1).optional(),
 
-  // Optional
-  openaiApiKey: z.string().optional(),
+    // Optional
+    openaiApiKey: z.string().optional(),
 
-  // Whisper transcription language (ISO-639-1 code, e.g. 'en', 'fr', 'de').
-  // If not set, Whisper auto-detects the language (may misidentify short clips).
-  whisperLanguage: z.preprocess(
-    (val) => {
-      if (typeof val !== 'string') return val;
-      const trimmed = val.trim();
-      if (trimmed === '') return undefined;
-      return trimmed.toLowerCase();
-    },
-    z.string().regex(/^[a-z]{2}$/, 'Must be an ISO-639-1 language code (e.g. en, fr, de)').optional(),
-  ),
+    // Whisper transcription language (ISO-639-1 code, e.g. 'en', 'fr', 'de').
+    // If not set, Whisper auto-detects the language (may misidentify short clips).
+    whisperLanguage: z.preprocess(
+      (val) => {
+        if (typeof val !== 'string') return val;
+        const trimmed = val.trim();
+        if (trimmed === '') return undefined;
+        return trimmed.toLowerCase();
+      },
+      z
+        .string()
+        .regex(/^[a-z]{2}$/, 'Must be an ISO-639-1 language code (e.g. en, fr, de)')
+        .optional(),
+    ),
 
-  // Multi-provider LLM support
-  llmApiKey: z.string().min(1).optional(),
-  llmBaseUrl: z.string().url().optional(),
+    // STT (Speech-to-Text) provider configuration
+    sttProvider: z
+      .enum([
+        'auto',
+        'openai',
+        'groq',
+        'together',
+        'siliconflow',
+        'deepinfra',
+        'fireworks',
+        'huggingface',
+        'openrouter',
+        'local',
+      ])
+      .default('auto'),
+    sttApiKey: z.string().optional(),
+    sttBaseUrl: z.string().url().optional(),
+    sttModel: z.string().optional(),
+    sttLocalCommand: z.string().optional(),
+    sttLocalModel: z.string().default('base.en'),
+    sttLocalModelDir: z.string().optional(),
 
-  // Redis
-  redisUrl: z.string().url().default('redis://localhost:6379'),
+    // Multi-provider LLM support
+    llmApiKey: z.string().min(1).optional(),
+    llmBaseUrl: z.string().url().optional(),
 
-  // Storage paths (resolve relative to ECHOS_HOME)
-  knowledgeDir: z.string().default(join(ECHOS_HOME, 'knowledge')),
-  dbPath: z.string().default(join(ECHOS_HOME, 'db')),
-  sessionDir: z.string().default(join(ECHOS_HOME, 'sessions')),
+    // Redis
+    redisUrl: z.string().url().default('redis://localhost:6379'),
 
-  // LLM
-  defaultModel: z.string().default('claude-haiku-4-5-20251001'),
-  embeddingModel: z.string().default('text-embedding-3-small'),
-  embeddingDimensions: z.coerce.number().int().positive().default(1536),
+    // Storage paths (resolve relative to ECHOS_HOME)
+    knowledgeDir: z.string().default(join(ECHOS_HOME, 'knowledge')),
+    dbPath: z.string().default(join(ECHOS_HOME, 'db')),
+    sessionDir: z.string().default(join(ECHOS_HOME, 'sessions')),
 
-  // Interfaces
-  enableTelegram: z
-    .string()
-    .default('true')
-    .transform((s) => s === 'true'),
-  enableWeb: z
-    .string()
-    .default('false')
-    .transform((s) => s === 'true'),
-  telegramReactions: z
-    .string()
-    .default('true')
-    .transform((s) => s === 'true'),
-  // Web
-  webPort: z.coerce.number().int().positive().default(3000),
-  webApiKey: z.string().optional(),
+    // LLM
+    defaultModel: z.string().default('claude-haiku-4-5-20251001'),
+    embeddingModel: z.string().default('text-embedding-3-small'),
+    embeddingDimensions: z.coerce.number().int().positive().default(1536),
 
-  // Webshare Proxy (optional)
-  webshareProxyUsername: z.string().optional(),
-  webshareProxyPassword: z.string().optional(),
+    // Interfaces
+    enableTelegram: z
+      .string()
+      .default('true')
+      .transform((s) => s === 'true'),
+    enableWeb: z
+      .string()
+      .default('false')
+      .transform((s) => s === 'true'),
+    telegramReactions: z
+      .string()
+      .default('true')
+      .transform((s) => s === 'true'),
+    // Web
+    webPort: z.coerce.number().int().positive().default(3000),
+    webApiKey: z.string().optional(),
 
-  // LLM model presets (for /model switching)
-  modelBalanced: z.string().optional(),
-  modelDeep: z.string().optional(),
+    // Webshare Proxy (optional)
+    webshareProxyUsername: z.string().optional(),
+    webshareProxyPassword: z.string().optional(),
 
-  // LLM reasoning
-  thinkingLevel: z.enum(['off', 'minimal', 'low', 'medium', 'high', 'xhigh']).default('off'),
+    // LLM model presets (for /model switching)
+    modelBalanced: z.string().optional(),
+    modelDeep: z.string().optional(),
 
-  // Prompt caching
-  cacheRetention: z.enum(['none', 'short', 'long']).default('long'),
+    // LLM reasoning
+    thinkingLevel: z.enum(['off', 'minimal', 'low', 'medium', 'high', 'xhigh']).default('off'),
 
-  // Debug
-  logLlmPayloads: z
-    .string()
-    .default('false')
-    .transform((s) => s === 'true'),
+    // Prompt caching
+    cacheRetention: z.enum(['none', 'short', 'long']).default('long'),
 
-  // Update checker
-  disableUpdateCheck: z
-    .string()
-    .default('false')
-    .transform((s) => s === 'true'),
+    // Debug
+    logLlmPayloads: z
+      .string()
+      .default('false')
+      .transform((s) => s === 'true'),
 
-  // Backup
-  backupEnabled: z
-    .string()
-    .default('true')
-    .transform((s) => s === 'true'),
-  backupCron: z
-    .string()
-    .default('0 2 * * *')
-    .refine(isValidCron, { message: 'BACKUP_CRON must be a valid 5-field cron expression (e.g. "0 2 * * *")' }),
-  backupDir: z.string().default(join(ECHOS_HOME, 'backups')),
-  backupRetentionCount: z.coerce.number().int().positive().default(7),
-})
-.superRefine((data, ctx) => {
-  // Note: we intentionally do NOT validate that the API key matches DEFAULT_MODEL's provider here.
-  // defaultModel has a schema-level default ('claude-haiku-4-5-20251001'), so we cannot distinguish
-  // "user didn't set DEFAULT_MODEL" from "user set it to the default value" after parsing.
-  // Mismatched key+model combos are caught at agent creation by pickApiKey() with a clear error.
-  if (!data.anthropicApiKey && !data.llmApiKey) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: 'At least one of ANTHROPIC_API_KEY or LLM_API_KEY must be set',
-      path: ['anthropicApiKey'],
-    });
-  }
-  if (data.llmBaseUrl && !data.llmApiKey) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: 'LLM_API_KEY must be set when LLM_BASE_URL is provided',
-      path: ['llmApiKey'],
-    });
-  }
-});
+    // Update checker
+    disableUpdateCheck: z
+      .string()
+      .default('false')
+      .transform((s) => s === 'true'),
+
+    // Backup
+    backupEnabled: z
+      .string()
+      .default('true')
+      .transform((s) => s === 'true'),
+    backupCron: z.string().default('0 2 * * *').refine(isValidCron, {
+      message: 'BACKUP_CRON must be a valid 5-field cron expression (e.g. "0 2 * * *")',
+    }),
+    backupDir: z.string().default(join(ECHOS_HOME, 'backups')),
+    backupRetentionCount: z.coerce.number().int().positive().default(7),
+  })
+  .superRefine((data, ctx) => {
+    // Note: we intentionally do NOT validate that the API key matches DEFAULT_MODEL's provider here.
+    // defaultModel has a schema-level default ('claude-haiku-4-5-20251001'), so we cannot distinguish
+    // "user didn't set DEFAULT_MODEL" from "user set it to the default value" after parsing.
+    // Mismatched key+model combos are caught at agent creation by pickApiKey() with a clear error.
+    if (!data.anthropicApiKey && !data.llmApiKey) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'At least one of ANTHROPIC_API_KEY or LLM_API_KEY must be set',
+        path: ['anthropicApiKey'],
+      });
+    }
+    if (data.llmBaseUrl && !data.llmApiKey) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'LLM_API_KEY must be set when LLM_BASE_URL is provided',
+        path: ['llmApiKey'],
+      });
+    }
+  });
 
 export type Config = z.infer<typeof configSchema>;
 
@@ -155,6 +179,13 @@ export function loadConfig(env: Record<string, string | undefined> = process.env
     anthropicApiKey: env['ANTHROPIC_API_KEY'],
     openaiApiKey: env['OPENAI_API_KEY'],
     whisperLanguage: env['WHISPER_LANGUAGE'],
+    sttProvider: env['STT_PROVIDER'],
+    sttApiKey: env['STT_API_KEY'],
+    sttBaseUrl: env['STT_BASE_URL'],
+    sttModel: env['STT_MODEL'],
+    sttLocalCommand: env['STT_LOCAL_COMMAND'],
+    sttLocalModel: env['STT_LOCAL_MODEL'],
+    sttLocalModelDir: env['STT_LOCAL_MODEL_DIR'],
     llmApiKey: env['LLM_API_KEY'],
     llmBaseUrl: env['LLM_BASE_URL'],
     redisUrl: env['REDIS_URL'],

--- a/packages/telegram/src/messages.ts
+++ b/packages/telegram/src/messages.ts
@@ -27,10 +27,7 @@ export function registerMessageHandlers(bot: Bot, deps: MessageDeps): void {
   // Handle document messages (PDF, CSV)
   const MAX_DOCUMENT_SIZE = 20 * 1024 * 1024; // 20 MB
   const DOWNLOAD_TIMEOUT_MS = 30_000;
-  const SUPPORTED_EXTS = new Set<string>([
-    '.pdf',
-    '.csv',
-  ]);
+  const SUPPORTED_EXTS = new Set<string>(['.pdf', '.csv']);
 
   bot.on('message:document', async (ctx) => {
     const doc = ctx.message?.document;
@@ -131,14 +128,15 @@ export function registerMessageHandlers(bot: Bot, deps: MessageDeps): void {
     const userId = ctx.from?.id;
     if (!userId) return;
 
-    if (!config.openaiApiKey) {
-      await ctx.reply('Voice messages require OpenAI API key configuration.');
+    const sttClient = agentDeps.sttClient;
+    if (!sttClient) {
+      await ctx.reply('Voice messages require STT provider configuration.');
       return;
     }
 
     if (config.telegramReactions) await ctx.react('🤗').catch(() => undefined);
     const agent = getOrCreateSession(userId, agentDeps);
-    await handleVoiceMessage(ctx, agent, config.openaiApiKey, logger, config.whisperLanguage);
+    await handleVoiceMessage(ctx, agent, sttClient, logger, config.whisperLanguage);
   });
 
   // Handle photo messages

--- a/packages/telegram/src/voice.ts
+++ b/packages/telegram/src/voice.ts
@@ -6,7 +6,8 @@ import { join } from 'node:path';
 import type { Context } from 'grammy';
 import type { Agent } from '@mariozechner/pi-agent-core';
 import type { Logger } from 'pino';
-import OpenAI from 'openai';
+import type { SpeechToTextClient, TranscribeOptions } from '@echos/core';
+import { transcribeWithRetry } from '@echos/core';
 import { streamAgentResponse } from './streaming.js';
 
 const MAX_VOICE_DURATION_SECONDS = 600; // 10 minutes
@@ -15,7 +16,7 @@ const MAX_FILE_SIZE_BYTES = 25 * 1024 * 1024; // 25MB — Whisper limit
 export async function handleVoiceMessage(
   ctx: Context,
   agent: Agent,
-  openaiApiKey: string,
+  sttClient: SpeechToTextClient,
   logger: Logger,
   language?: string,
 ): Promise<void> {
@@ -39,7 +40,11 @@ export async function handleVoiceMessage(
     const file = await ctx.api.getFile(voice.file_id);
     const filePath = file.file_path;
     if (!filePath) {
-      await ctx.api.editMessageText(ctx.chat!.id, statusMsg.message_id, '❌ Failed to retrieve voice file.');
+      await ctx.api.editMessageText(
+        ctx.chat!.id,
+        statusMsg.message_id,
+        '❌ Failed to retrieve voice file.',
+      );
       return;
     }
 
@@ -61,23 +66,18 @@ export async function handleVoiceMessage(
 
     await writeFile(tempFilePath, audioBuffer);
 
-    const openai = new OpenAI({ apiKey: openaiApiKey });
-    const audioStream = createReadStream(tempFilePath) as unknown as File;
-    const transcription = await openai.audio.transcriptions.create({
-      file: audioStream,
-      model: 'whisper-1',
-      response_format: 'text',
+    const result = await transcribeWithRetry(sttClient, {
+      audioBuffer,
+      mimeType: 'audio/ogg',
       ...(language ? { language } : {}),
     });
 
-    const transcribedText = typeof transcription === 'string' ? transcription.trim() : '';
+    const transcribedText = result.text.trim();
 
     if (!transcribedText) {
-      await ctx.api.setMessageReaction(
-        ctx.chat!.id,
-        ctx.message!.message_id,
-        [{ type: 'emoji', emoji: '😱' }],
-      ).catch(() => undefined);
+      await ctx.api
+        .setMessageReaction(ctx.chat!.id, ctx.message!.message_id, [{ type: 'emoji', emoji: '😱' }])
+        .catch(() => undefined);
       await ctx.api.editMessageText(
         ctx.chat!.id,
         statusMsg.message_id,
@@ -86,8 +86,12 @@ export async function handleVoiceMessage(
       return;
     }
 
-    const preview = transcribedText.length > 200 ? `${transcribedText.slice(0, 200)}...` : transcribedText;
-    logger.info({ preview }, 'Voice message transcribed');
+    const preview =
+      transcribedText.length > 200 ? `${transcribedText.slice(0, 200)}...` : transcribedText;
+    logger.info(
+      { preview, provider: result.provider, duration: result.duration },
+      'Voice message transcribed',
+    );
 
     await ctx.api.editMessageText(
       ctx.chat!.id,
@@ -98,11 +102,9 @@ export async function handleVoiceMessage(
     await streamAgentResponse(agent, transcribedText, ctx);
   } catch (err) {
     logger.error({ err }, 'Failed to process voice message');
-    await ctx.api.setMessageReaction(
-      ctx.chat!.id,
-      ctx.message!.message_id,
-      [{ type: 'emoji', emoji: '😱' }],
-    ).catch(() => undefined);
+    await ctx.api
+      .setMessageReaction(ctx.chat!.id, ctx.message!.message_id, [{ type: 'emoji', emoji: '😱' }])
+      .catch(() => undefined);
     await ctx.api.editMessageText(
       ctx.chat!.id,
       statusMsg.message_id,

--- a/plugins/audio/package.json
+++ b/plugins/audio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@echos/plugin-audio",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",
@@ -14,15 +14,15 @@
   "dependencies": {
     "@echos/core": "workspace:*",
     "@echos/shared": "workspace:*",
-    "@mariozechner/pi-agent-core": "^0.64.0",
-    "@mariozechner/pi-ai": "^0.64.0",
+    "@mariozechner/pi-agent-core": "^0.65.2",
+    "@mariozechner/pi-ai": "^0.65.2",
     "@sinclair/typebox": "^0.34.49",
     "openai": "^6.33.0",
     "pino": "^10.3.1",
     "uuid": "^13.0.0"
   },
   "devDependencies": {
-    "@types/node": "^25.5.0",
+    "@types/node": "^25.5.2",
     "@types/uuid": "^11.0.0",
     "typescript": "^5.7.0"
   }

--- a/plugins/audio/src/tool.ts
+++ b/plugins/audio/src/tool.ts
@@ -1,16 +1,14 @@
 import { randomUUID } from 'node:crypto';
 import { tmpdir } from 'node:os';
 import { writeFile, unlink } from 'node:fs/promises';
-import { createReadStream } from 'node:fs';
 import { join, extname } from 'node:path';
 import { Type, type Static } from '@mariozechner/pi-ai';
 import type { AgentTool } from '@mariozechner/pi-agent-core';
 import { v4 as uuidv4 } from 'uuid';
-import OpenAI from 'openai';
 import type { NoteMetadata } from '@echos/shared';
 import { validateUrl } from '@echos/shared';
-import type { PluginContext } from '@echos/core';
-import { categorizeContent, type ProcessingMode } from '@echos/core';
+import type { PluginContext, SpeechToTextClient, TranscribeOptions } from '@echos/core';
+import { categorizeContent, type ProcessingMode, transcribeWithRetry } from '@echos/core';
 import {
   WHISPER_MAX_BYTES,
   downloadInChunks,
@@ -49,9 +47,11 @@ function formatBytes(bytes: number): string {
 function estimateDuration(bytes: number, mimeType: string): string {
   // Approximate average bitrates for common formats
   const bitrateKbps =
-    mimeType === 'audio/wav' ? 1411 :   // uncompressed
-    mimeType === 'audio/flac' ? 800 :   // lossless compressed
-    128;                                 // compressed (mp3/ogg/m4a/etc.)
+    mimeType === 'audio/wav'
+      ? 1411 // uncompressed
+      : mimeType === 'audio/flac'
+        ? 800 // lossless compressed
+        : 128; // compressed (mp3/ogg/m4a/etc.)
 
   const seconds = Math.round((bytes * 8) / (bitrateKbps * 1000));
   const minutes = Math.floor(seconds / 60);
@@ -60,9 +60,18 @@ function estimateDuration(bytes: number, mimeType: string): string {
 }
 
 const schema = Type.Object({
-  url: Type.String({ description: 'URL of the audio file or podcast episode to download and transcribe', format: 'uri' }),
-  title: Type.Optional(Type.String({ description: 'Optional title for the saved note (defaults to filename from URL)' })),
-  tags: Type.Optional(Type.Array(Type.String(), { description: 'Tags to apply to the saved note' })),
+  url: Type.String({
+    description: 'URL of the audio file or podcast episode to download and transcribe',
+    format: 'uri',
+  }),
+  title: Type.Optional(
+    Type.String({
+      description: 'Optional title for the saved note (defaults to filename from URL)',
+    }),
+  ),
+  tags: Type.Optional(
+    Type.Array(Type.String(), { description: 'Tags to apply to the saved note' }),
+  ),
   categorize: Type.Optional(
     Type.Boolean({
       description: 'Automatically categorize using AI (default: true)',
@@ -74,31 +83,21 @@ const schema = Type.Object({
 type Params = Static<typeof schema>;
 
 /**
- * Transcribe a single audio buffer via the Whisper API.
- * Writes the buffer to a temp file (Whisper SDK requires a readable stream),
- * then cleans up.
+ * Transcribe a single audio buffer via the configured STT provider.
  */
 async function transcribeBuffer(
-  openai: OpenAI,
+  sttClient: SpeechToTextClient,
   data: Buffer,
   filename: string,
   language?: string,
 ): Promise<string> {
-  const ext = extname(filename) || '.mp3';
-  const tempPath = join(tmpdir(), `echos-audio-${randomUUID()}${ext}`);
-  try {
-    await writeFile(tempPath, data);
-    const stream = createReadStream(tempPath) as unknown as File;
-    const result = await openai.audio.transcriptions.create({
-      file: stream,
-      model: 'whisper-1',
-      response_format: 'text',
-      ...(language ? { language } : {}),
-    });
-    return typeof result === 'string' ? result.trim() : '';
-  } finally {
-    await unlink(tempPath).catch(() => undefined);
-  }
+  const mimeType = getAudioMime(filename) || 'audio/mpeg';
+  const result = await transcribeWithRetry(sttClient, {
+    audioBuffer: data,
+    mimeType,
+    ...(language ? { language } : {}),
+  });
+  return result.text;
 }
 
 export function createSaveAudioTool(context: PluginContext): AgentTool<typeof schema> {
@@ -131,23 +130,28 @@ export function createSaveAudioTool(context: PluginContext): AgentTool<typeof sc
 
       if (mimeType === undefined) {
         return {
-          content: [{
-            type: 'text' as const,
-            text: `Unsupported audio format. Supported extensions: ${Object.keys(SUPPORTED_EXTENSIONS).join(', ')}. ` +
-                  `Got: "${extname(urlFilename) || '(no extension)'}"`,
-          }],
+          content: [
+            {
+              type: 'text' as const,
+              text:
+                `Unsupported audio format. Supported extensions: ${Object.keys(SUPPORTED_EXTENSIONS).join(', ')}. ` +
+                `Got: "${extname(urlFilename) || '(no extension)'}"`,
+            },
+          ],
           details: { error: 'unsupported_format' },
         };
       }
 
-      const openaiApiKey = context.config.openaiApiKey;
-      if (!openaiApiKey) {
+      const sttClient = context.sttClient;
+      if (!sttClient) {
         return {
-          content: [{
-            type: 'text' as const,
-            text: 'OPENAI_API_KEY is not configured. Whisper transcription requires an OpenAI API key.',
-          }],
-          details: { error: 'missing_api_key' },
+          content: [
+            {
+              type: 'text' as const,
+              text: 'STT provider is not configured. Set STT_API_KEY (or STT_PROVIDER=local) to enable transcription.',
+            },
+          ],
+          details: { error: 'missing_stt_config' },
         };
       }
 
@@ -180,10 +184,10 @@ export function createSaveAudioTool(context: PluginContext): AgentTool<typeof sc
         contentLength = await probeContentLength(safeUrl);
       }
 
-      const openai = new OpenAI({ apiKey: openaiApiKey as string });
-      const language = typeof context.config['whisperLanguage'] === 'string'
-        ? context.config['whisperLanguage']
-        : undefined;
+      const language =
+        typeof context.config['whisperLanguage'] === 'string'
+          ? context.config['whisperLanguage']
+          : undefined;
 
       let transcript: string;
       let fileSizeBytes: number;
@@ -192,10 +196,12 @@ export function createSaveAudioTool(context: PluginContext): AgentTool<typeof sc
         // Large file: split into chunks
         const chunkCount = Math.ceil(contentLength / (24 * 1024 * 1024));
         onUpdate?.({
-          content: [{
-            type: 'text',
-            text: `Audio is ${formatBytes(contentLength)} — splitting into ${chunkCount} chunks for Whisper...`,
-          }],
+          content: [
+            {
+              type: 'text',
+              text: `Audio is ${formatBytes(contentLength)} — splitting into ${chunkCount} chunks for Whisper...`,
+            },
+          ],
           details: { phase: 'chunking', contentLength, chunkCount },
         });
 
@@ -215,23 +221,27 @@ export function createSaveAudioTool(context: PluginContext): AgentTool<typeof sc
 
         for (const chunk of chunks) {
           onUpdate?.({
-            content: [{
-              type: 'text',
-              text: `Transcribing chunk ${chunk.index + 1}/${chunk.total} (${formatBytes(chunk.data.length)})...`,
-            }],
+            content: [
+              {
+                type: 'text',
+                text: `Transcribing chunk ${chunk.index + 1}/${chunk.total} (${formatBytes(chunk.data.length)})...`,
+              },
+            ],
             details: { phase: 'transcribing', chunkIndex: chunk.index, chunkTotal: chunk.total },
           });
 
           let chunkText: string;
           try {
-            chunkText = await transcribeBuffer(openai, chunk.data, urlFilename, language);
+            chunkText = await transcribeBuffer(sttClient, chunk.data, urlFilename, language);
           } catch (err) {
             const message = err instanceof Error ? err.message : String(err);
             return {
-              content: [{
-                type: 'text' as const,
-                text: `Transcription failed on chunk ${chunk.index + 1}/${chunk.total}: ${message}`,
-              }],
+              content: [
+                {
+                  type: 'text' as const,
+                  text: `Transcription failed on chunk ${chunk.index + 1}/${chunk.total}: ${message}`,
+                },
+              ],
               details: { error: message },
             };
           }
@@ -261,12 +271,17 @@ export function createSaveAudioTool(context: PluginContext): AgentTool<typeof sc
         fileSizeBytes = audioBuffer.length;
 
         onUpdate?.({
-          content: [{ type: 'text', text: `Transcribing ${formatBytes(fileSizeBytes)} of audio via Whisper...` }],
+          content: [
+            {
+              type: 'text',
+              text: `Transcribing ${formatBytes(fileSizeBytes)} of audio via Whisper...`,
+            },
+          ],
           details: { phase: 'transcribing' },
         });
 
         try {
-          transcript = await transcribeBuffer(openai, audioBuffer, urlFilename, language);
+          transcript = await transcribeBuffer(sttClient, audioBuffer, urlFilename, language);
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
           return {
@@ -278,10 +293,12 @@ export function createSaveAudioTool(context: PluginContext): AgentTool<typeof sc
 
       if (!transcript) {
         return {
-          content: [{
-            type: 'text' as const,
-            text: 'Whisper returned an empty transcript. The audio may be silent or in an unsupported language.',
-          }],
+          content: [
+            {
+              type: 'text' as const,
+              text: 'Whisper returned an empty transcript. The audio may be silent or in an unsupported language.',
+            },
+          ],
           details: { error: 'empty_transcript' },
         };
       }

--- a/plugins/youtube/src/processor.ts
+++ b/plugins/youtube/src/processor.ts
@@ -1,5 +1,4 @@
 import ytdl from '@distube/ytdl-core';
-import OpenAI from 'openai';
 import { createWriteStream } from 'fs';
 import { unlink, mkdir } from 'fs/promises';
 import { tmpdir } from 'os';
@@ -11,6 +10,8 @@ import { YouTubeTranscriptApi, WebshareProxyConfig } from 'youtube-transcript-ap
 import type { ProxyConfig as TranscriptProxyConfig } from 'youtube-transcript-api-js';
 import { validateUrl, sanitizeHtml, ProcessingError, ExternalServiceError } from '@echos/shared';
 import type { ProcessedContent } from '@echos/shared';
+import type { SpeechToTextClient, TranscribeOptions } from '@echos/core';
+import { transcribeWithRetry } from '@echos/core';
 
 export type ProxyConfig = { username: string; password: string } | undefined;
 
@@ -99,7 +100,12 @@ export function extractVideoId(url: string): string {
 /**
  * Fetch transcript using youtube-transcript-api-js (pure JS, no Python dependency)
  */
-async function fetchYoutubeTranscript(videoId: string, logger: Logger, proxyConfig?: ProxyConfig, signal?: AbortSignal): Promise<string> {
+async function fetchYoutubeTranscript(
+  videoId: string,
+  logger: Logger,
+  proxyConfig?: ProxyConfig,
+  signal?: AbortSignal,
+): Promise<string> {
   logger.debug({ videoId, hasProxy: !!proxyConfig }, 'Fetching YouTube transcript');
 
   const transcriptProxyConfig = createTranscriptProxyConfig(proxyConfig);
@@ -111,17 +117,22 @@ async function fetchYoutubeTranscript(videoId: string, logger: Logger, proxyConf
     const timeoutId = setTimeout(() => {
       reject(new ProcessingError('Transcript fetch timeout', true));
     }, TRANSCRIPT_TIMEOUT_MS);
-    signal?.addEventListener('abort', () => {
-      clearTimeout(timeoutId);
-      reject(signal.reason instanceof Error ? signal.reason : new ProcessingError('Agent turn cancelled'));
-    }, { once: true });
+    signal?.addEventListener(
+      'abort',
+      () => {
+        clearTimeout(timeoutId);
+        reject(
+          signal.reason instanceof Error
+            ? signal.reason
+            : new ProcessingError('Agent turn cancelled'),
+        );
+      },
+      { once: true },
+    );
   });
 
   try {
-    const transcriptList = await Promise.race([
-      api.list(videoId),
-      timeoutPromise,
-    ]);
+    const transcriptList = await Promise.race([api.list(videoId), timeoutPromise]);
 
     // Try to find transcript in order: manual en, generated en, any available
     let fetchedTranscript;
@@ -149,15 +160,12 @@ async function fetchYoutubeTranscript(videoId: string, logger: Logger, proxyConf
     }
 
     if (text.length > MAX_TRANSCRIPT_LENGTH) {
-      throw new ProcessingError(
-        `Transcript too long: ${text.length} characters`,
-        false
-      );
+      throw new ProcessingError(`Transcript too long: ${text.length} characters`, false);
     }
 
     logger.info(
       { videoId, transcriptLength: text.length, segments: fetchedTranscript.snippets.length },
-      'YouTube transcript fetched successfully'
+      'YouTube transcript fetched successfully',
     );
     return text;
   } catch (error) {
@@ -169,16 +177,23 @@ async function fetchYoutubeTranscript(videoId: string, logger: Logger, proxyConf
     const errorName = error instanceof Error ? error.constructor.name : typeof error;
     logger.warn(
       { videoId, errorName, error: errorMessage, hasProxy: !!proxyConfig },
-      'YouTube transcript unavailable'
+      'YouTube transcript unavailable',
     );
-    throw new ProcessingError(`YouTube transcript unavailable [${errorName}]: ${errorMessage}`, true);
+    throw new ProcessingError(
+      `YouTube transcript unavailable [${errorName}]: ${errorMessage}`,
+      true,
+    );
   }
 }
 
 /**
  * Download audio from YouTube video
  */
-async function downloadAudio(videoId: string, logger: Logger, proxyConfig?: ProxyConfig): Promise<string> {
+async function downloadAudio(
+  videoId: string,
+  logger: Logger,
+  proxyConfig?: ProxyConfig,
+): Promise<string> {
   const url = `https://www.youtube.com/watch?v=${videoId}`;
   const tempFilePath = join(tmpdir(), `youtube_${videoId}_${Date.now()}.mp3`);
 
@@ -216,8 +231,8 @@ async function downloadAudio(videoId: string, logger: Logger, proxyConfig?: Prox
           reject(
             new ProcessingError(
               `Audio file too large: ${(downloadedBytes / 1024 / 1024).toFixed(2)}MB`,
-              false
-            )
+              false,
+            ),
           );
         }
       });
@@ -238,7 +253,7 @@ async function downloadAudio(videoId: string, logger: Logger, proxyConfig?: Prox
         clearTimeout(timeout);
         logger.debug(
           { videoId, tempFilePath, sizeBytes: downloadedBytes },
-          'Audio download complete'
+          'Audio download complete',
         );
         resolve(tempFilePath);
       });
@@ -256,57 +271,59 @@ async function downloadAudio(videoId: string, logger: Logger, proxyConfig?: Prox
 }
 
 /**
- * Transcribe audio using OpenAI Whisper
+ * Transcribe audio using the configured STT provider
  */
 async function transcribeWithWhisper(
   audioFilePath: string,
   videoId: string,
-  openaiApiKey: string,
+  sttClient: SpeechToTextClient,
   logger: Logger,
   language?: string,
 ): Promise<string> {
   logger.debug({ videoId, audioFilePath }, 'Transcribing with Whisper');
 
-  const openai = new OpenAI({ apiKey: openaiApiKey });
-
   try {
-    const { createReadStream } = await import('fs');
-    const audioStream = createReadStream(audioFilePath) as unknown as File;
+    const { readFile } = await import('fs/promises');
+    const audioBuffer = await readFile(audioFilePath);
 
-    const transcription = await openai.audio.transcriptions.create({
-      file: audioStream,
-      model: 'whisper-1',
-      response_format: 'text',
+    const mimeType = audioFilePath.endsWith('.mp3')
+      ? 'audio/mpeg'
+      : audioFilePath.endsWith('.wav')
+        ? 'audio/wav'
+        : audioFilePath.endsWith('.ogg')
+          ? 'audio/ogg'
+          : 'audio/mpeg';
+
+    const result = await transcribeWithRetry(sttClient, {
+      audioBuffer,
+      mimeType,
       ...(language ? { language } : {}),
     });
 
-    if (!transcription || typeof transcription !== 'string') {
+    if (!result.text) {
       throw new ProcessingError('Empty transcription returned from Whisper', false);
     }
 
-    if (transcription.length > MAX_TRANSCRIPT_LENGTH) {
-      throw new ProcessingError(
-        `Transcription too long: ${transcription.length} characters`,
-        false
-      );
+    if (result.text.length > MAX_TRANSCRIPT_LENGTH) {
+      throw new ProcessingError(`Transcription too long: ${result.text.length} characters`, false);
     }
 
     logger.info(
-      { videoId, transcriptionLength: transcription.length },
-      'Whisper transcription complete'
+      { videoId, transcriptionLength: result.text.length, provider: result.provider },
+      'Whisper transcription complete',
     );
 
-    return transcription;
+    return result.text;
   } catch (error) {
     if (error instanceof ProcessingError) {
       throw error;
     }
 
     if (error instanceof Error) {
-      throw new ExternalServiceError('OpenAI Whisper', error.message);
+      throw new ExternalServiceError('STT', error.message);
     }
 
-    throw new ExternalServiceError('OpenAI Whisper', 'Unknown transcription error');
+    throw new ExternalServiceError('STT', 'Unknown transcription error');
   }
 }
 
@@ -325,13 +342,16 @@ async function getVideoMetadata(
     const oembedUrl = `https://www.youtube.com/oembed?url=https://www.youtube.com/watch?v=${videoId}&format=json`;
     const response = await fetch(oembedUrl, {
       headers: {
-        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+        'User-Agent':
+          'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
       },
-      signal: signal ? AbortSignal.any([signal, AbortSignal.timeout(10000)]) : AbortSignal.timeout(10000),
+      signal: signal
+        ? AbortSignal.any([signal, AbortSignal.timeout(10000)])
+        : AbortSignal.timeout(10000),
     });
 
     if (response.ok) {
-      const data = await response.json() as { title?: string; author_name?: string };
+      const data = (await response.json()) as { title?: string; author_name?: string };
       const title = data.title || 'Untitled';
       const channel = data.author_name || undefined;
       logger.info({ videoId, title, channel }, 'Metadata fetched via oEmbed');
@@ -351,15 +371,18 @@ async function getVideoMetadata(
   try {
     const url = `https://www.youtube.com/watch?v=${videoId}`;
     const agent = createProxyAgent(proxyConfig);
-    const info = await withYtdlCache(async () => ytdl.getInfo(url, {
-      requestOptions: {
-        headers: {
-          'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
-          'Accept-Language': 'en-US,en;q=0.9',
+    const info = await withYtdlCache(async () =>
+      ytdl.getInfo(url, {
+        requestOptions: {
+          headers: {
+            'User-Agent':
+              'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+            'Accept-Language': 'en-US,en;q=0.9',
+          },
+          ...(agent ? { agent } : {}),
         },
-        ...(agent ? { agent } : {}),
-      },
-    }));
+      }),
+    );
 
     const title = info.videoDetails.title || 'Untitled';
     const channel = info.videoDetails.author.name;
@@ -374,7 +397,10 @@ async function getVideoMetadata(
     };
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-    logger.warn({ videoId, error: errorMessage }, 'ytdl-core metadata also failed, using dummy title');
+    logger.warn(
+      { videoId, error: errorMessage },
+      'ytdl-core metadata also failed, using dummy title',
+    );
     return { title: `YouTube Video ${videoId}` };
   }
 }
@@ -385,7 +411,7 @@ async function getVideoMetadata(
 export async function processYoutube(
   url: string,
   logger: Logger,
-  openaiApiKey?: string,
+  sttClient?: SpeechToTextClient,
   proxyConfig?: ProxyConfig,
   whisperLanguage?: string,
   signal?: AbortSignal,
@@ -413,19 +439,25 @@ export async function processYoutube(
       transcriptError instanceof Error ? transcriptError.message : 'Unknown error';
     logger.warn(
       { videoId, error: errorMessage },
-      'YouTube transcript unavailable, falling back to Whisper'
+      'YouTube transcript unavailable, falling back to Whisper',
     );
 
-    if (!openaiApiKey) {
+    if (!sttClient) {
       throw new ProcessingError(
-        'YouTube transcript unavailable and OpenAI API key not configured. Please set OPENAI_API_KEY in .env to enable Whisper transcription fallback.',
-        false
+        'YouTube transcript unavailable and STT provider not configured. Please set STT_API_KEY (or STT_PROVIDER=local) to enable Whisper transcription fallback.',
+        false,
       );
     }
 
     try {
       audioFilePath = await downloadAudio(videoId, logger, proxyConfig);
-      transcript = await transcribeWithWhisper(audioFilePath, videoId, openaiApiKey, logger, whisperLanguage);
+      transcript = await transcribeWithWhisper(
+        audioFilePath,
+        videoId,
+        sttClient,
+        logger,
+        whisperLanguage,
+      );
       transcriptSource = 'whisper';
 
       logger.info({ videoId, source: 'whisper' }, 'Transcript obtained from Whisper');
@@ -434,22 +466,26 @@ export async function processYoutube(
         try {
           await unlink(audioFilePath);
         } catch (unlinkError) {
-          logger.warn({ audioFilePath, error: unlinkError }, 'Failed to delete temporary audio file');
+          logger.warn(
+            { audioFilePath, error: unlinkError },
+            'Failed to delete temporary audio file',
+          );
         }
       }
 
-      const whisperErrorMsg = whisperError instanceof Error ? whisperError.message : 'Unknown error';
+      const whisperErrorMsg =
+        whisperError instanceof Error ? whisperError.message : 'Unknown error';
 
       if (whisperErrorMsg.includes('403')) {
         throw new ProcessingError(
           'YouTube transcript unavailable and video download blocked by YouTube. Please try a video with captions/subtitles enabled.',
-          false
+          false,
         );
       }
 
       throw new ProcessingError(
         `Unable to get transcript: YouTube transcript unavailable and Whisper download failed. This video may have restricted access.`,
-        false
+        false,
       );
     }
 
@@ -474,7 +510,7 @@ export async function processYoutube(
       channel: sanitizedChannel,
       transcriptSource,
     },
-    'YouTube video processed successfully'
+    'YouTube video processed successfully',
   );
 
   return {

--- a/plugins/youtube/src/tool.ts
+++ b/plugins/youtube/src/tool.ts
@@ -29,7 +29,6 @@ const schema = Type.Object({
 type Params = Static<typeof schema>;
 
 export function createSaveYoutubeTool(context: PluginContext): AgentTool<typeof schema> {
-  const openaiApiKey = context.config['openaiApiKey'] as string | undefined;
   const whisperLanguage = context.config['whisperLanguage'] as string | undefined;
   const proxyUsername = context.config['webshareProxyUsername'] as string | undefined;
   const proxyPassword = context.config['webshareProxyPassword'] as string | undefined;
@@ -50,7 +49,14 @@ export function createSaveYoutubeTool(context: PluginContext): AgentTool<typeof 
         details: { phase: 'fetching' },
       });
 
-      const processed = await processYoutube(params.url, context.logger, openaiApiKey, proxyConfig, whisperLanguage, signal ?? undefined);
+      const processed = await processYoutube(
+        params.url,
+        context.logger,
+        context.sttClient,
+        proxyConfig,
+        whisperLanguage,
+        signal ?? undefined,
+      );
       validateContentSize(processed.content, { label: 'video transcript' });
 
       const now = new Date().toISOString();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,7 +74,7 @@ importers:
         version: 10.0.1(eslint@10.1.0)
       '@vitest/coverage-v8':
         specifier: ^4.1.2
-        version: 4.1.2(vitest@4.1.2(@types/node@25.5.0)(jsdom@29.0.1)(vite@7.3.1(@types/node@25.5.0)(tsx@4.21.0)))
+        version: 4.1.2(vitest@4.1.2(@types/node@25.5.2)(jsdom@29.0.1)(vite@7.3.1(@types/node@25.5.2)(tsx@4.21.0)))
       eslint:
         specifier: ^10.1.0
         version: 10.1.0
@@ -101,7 +101,7 @@ importers:
         version: 8.57.2(eslint@10.1.0)(typescript@5.9.3)
       vitest:
         specifier: ^4.1.2
-        version: 4.1.2(@types/node@25.5.0)(jsdom@29.0.1)(vite@7.3.1(@types/node@25.5.0)(tsx@4.21.0))
+        version: 4.1.2(@types/node@25.5.2)(jsdom@29.0.1)(vite@7.3.1(@types/node@25.5.2)(tsx@4.21.0))
 
   packages/cli:
     dependencies:
@@ -368,11 +368,11 @@ importers:
         specifier: workspace:*
         version: link:../../packages/shared
       '@mariozechner/pi-agent-core':
-        specifier: ^0.64.0
-        version: 0.64.0(ws@8.20.0)(zod@4.3.6)
+        specifier: ^0.65.2
+        version: 0.65.2(ws@8.20.0)(zod@4.3.6)
       '@mariozechner/pi-ai':
-        specifier: ^0.64.0
-        version: 0.64.0(ws@8.20.0)(zod@4.3.6)
+        specifier: ^0.65.2
+        version: 0.65.2(ws@8.20.0)(zod@4.3.6)
       '@sinclair/typebox':
         specifier: ^0.34.49
         version: 0.34.49
@@ -387,8 +387,8 @@ importers:
         version: 13.0.0
     devDependencies:
       '@types/node':
-        specifier: ^25.5.0
-        version: 25.5.0
+        specifier: ^25.5.2
+        version: 25.5.2
       '@types/uuid':
         specifier: ^11.0.0
         version: 11.0.0
@@ -1611,8 +1611,17 @@ packages:
     resolution: {integrity: sha512-IN/sIxWOD0v1OFVXHB605SGiZhO5XdEWG5dO8EAV08n3jz/p12o4OuYGvhGXmHhU28WXa/FGWC+FO5xiIih8Uw==}
     engines: {node: '>=20.0.0'}
 
+  '@mariozechner/pi-agent-core@0.65.2':
+    resolution: {integrity: sha512-GYOrX5aRUpSDMPtKR174Tv72CWH92anqlRuiGn8PV05OowPAahT99JoxvZEP4fcKANBdHsyDfMMwFYpPhvPBUQ==}
+    engines: {node: '>=20.0.0'}
+
   '@mariozechner/pi-ai@0.64.0':
     resolution: {integrity: sha512-Z/Jnf+JSVDPLRcxJsa8XhYTJKIqKekNueaCpBLGQHgizL1F9RQ1Rur3rIfZpfXkt2cLu/AIPtOs223ueuoWaWg==}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
+
+  '@mariozechner/pi-ai@0.65.2':
+    resolution: {integrity: sha512-XCbXncmh10Q89tvS0880Ms6pv3DTxFTEtanfVHEPXKQBi0FBYnrkAlOnP5VRU8vCfe18P1AMNsWCndsCBUqY7g==}
     engines: {node: '>=20.0.0'}
     hasBin: true
 
@@ -2061,6 +2070,9 @@ packages:
   '@types/node@25.5.0':
     resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
 
+  '@types/node@25.5.2':
+    resolution: {integrity: sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==}
+
   '@types/pdf-parse@1.1.5':
     resolution: {integrity: sha512-kBfrSXsloMnUJOKi25s3+hRmkycHfLK6A09eRGqF/N8BkQoPUmaCr+q8Cli5FnfohEz/rsv82zAiPz/LXtOGhA==}
 
@@ -2266,6 +2278,7 @@ packages:
   basic-ftp@5.2.0:
     resolution: {integrity: sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==}
     engines: {node: '>=10.0.0'}
+    deprecated: Security vulnerability fixed in 5.2.1, please upgrade
 
   better-sqlite3@12.8.0:
     resolution: {integrity: sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==}
@@ -4674,7 +4687,43 @@ snapshots:
       - ws
       - zod
 
+  '@mariozechner/pi-agent-core@0.65.2(ws@8.20.0)(zod@4.3.6)':
+    dependencies:
+      '@mariozechner/pi-ai': 0.65.2(ws@8.20.0)(zod@4.3.6)
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - aws-crt
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
   '@mariozechner/pi-ai@0.64.0(ws@8.20.0)(zod@4.3.6)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.73.0(zod@4.3.6)
+      '@aws-sdk/client-bedrock-runtime': 3.1019.0
+      '@google/genai': 1.47.0
+      '@mistralai/mistralai': 1.14.1
+      '@sinclair/typebox': 0.34.49
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      chalk: 5.6.2
+      openai: 6.26.0(ws@8.20.0)(zod@4.3.6)
+      partial-json: 0.1.7
+      proxy-agent: 6.5.0
+      undici: 7.24.6
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - aws-crt
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@mariozechner/pi-ai@0.65.2(ws@8.20.0)(zod@4.3.6)':
     dependencies:
       '@anthropic-ai/sdk': 0.73.0(zod@4.3.6)
       '@aws-sdk/client-bedrock-runtime': 3.1019.0
@@ -5178,9 +5227,13 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
+  '@types/node@25.5.2':
+    dependencies:
+      undici-types: 7.18.2
+
   '@types/pdf-parse@1.1.5':
     dependencies:
-      '@types/node': 25.5.0
+      '@types/node': 25.5.2
 
   '@types/retry@0.12.0': {}
 
@@ -5284,7 +5337,7 @@ snapshots:
       '@typescript-eslint/types': 8.57.2
       eslint-visitor-keys: 5.0.1
 
-  '@vitest/coverage-v8@4.1.2(vitest@4.1.2(@types/node@25.5.0)(jsdom@29.0.1)(vite@7.3.1(@types/node@25.5.0)(tsx@4.21.0)))':
+  '@vitest/coverage-v8@4.1.2(vitest@4.1.2(@types/node@25.5.2)(jsdom@29.0.1)(vite@7.3.1(@types/node@25.5.2)(tsx@4.21.0)))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.1.2
@@ -5296,7 +5349,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.2(@types/node@25.5.0)(jsdom@29.0.1)(vite@7.3.1(@types/node@25.5.0)(tsx@4.21.0))
+      vitest: 4.1.2(@types/node@25.5.2)(jsdom@29.0.1)(vite@7.3.1(@types/node@25.5.2)(tsx@4.21.0))
 
   '@vitest/expect@4.1.2':
     dependencies:
@@ -5307,13 +5360,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.2(vite@7.3.1(@types/node@25.5.0)(tsx@4.21.0))':
+  '@vitest/mocker@4.1.2(vite@7.3.1(@types/node@25.5.2)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 4.1.2
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.5.0)(tsx@4.21.0)
+      vite: 7.3.1(@types/node@25.5.2)(tsx@4.21.0)
 
   '@vitest/pretty-format@4.1.2':
     dependencies:
@@ -6518,7 +6571,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 25.5.0
+      '@types/node': 25.5.2
       long: 5.3.2
 
   proxy-agent@6.5.0:
@@ -6904,7 +6957,7 @@ snapshots:
 
   uuid@13.0.0: {}
 
-  vite@7.3.1(@types/node@25.5.0)(tsx@4.21.0):
+  vite@7.3.1(@types/node@25.5.2)(tsx@4.21.0):
     dependencies:
       esbuild: 0.27.4
       fdir: 6.5.0(picomatch@4.0.4)
@@ -6913,14 +6966,14 @@ snapshots:
       rollup: 4.60.1
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 25.5.0
+      '@types/node': 25.5.2
       fsevents: 2.3.3
       tsx: 4.21.0
 
-  vitest@4.1.2(@types/node@25.5.0)(jsdom@29.0.1)(vite@7.3.1(@types/node@25.5.0)(tsx@4.21.0)):
+  vitest@4.1.2(@types/node@25.5.2)(jsdom@29.0.1)(vite@7.3.1(@types/node@25.5.2)(tsx@4.21.0)):
     dependencies:
       '@vitest/expect': 4.1.2
-      '@vitest/mocker': 4.1.2(vite@7.3.1(@types/node@25.5.0)(tsx@4.21.0))
+      '@vitest/mocker': 4.1.2(vite@7.3.1(@types/node@25.5.2)(tsx@4.21.0))
       '@vitest/pretty-format': 4.1.2
       '@vitest/runner': 4.1.2
       '@vitest/snapshot': 4.1.2
@@ -6937,10 +6990,10 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 7.3.1(@types/node@25.5.0)(tsx@4.21.0)
+      vite: 7.3.1(@types/node@25.5.2)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 25.5.0
+      '@types/node': 25.5.2
       jsdom: 29.0.1
     transitivePeerDependencies:
       - msw

--- a/scripts/whisper-cpp-wrapper.py
+++ b/scripts/whisper-cpp-wrapper.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""
+whisper-cpp wrapper script for EchOS local STT.
+Uses the whispercpp Python package to transcribe audio files.
+
+Usage:
+    whisper-cpp-wrapper.py -m MODEL -f AUDIO_FILE [-l LANGUAGE] [-o OUTPUT_DIR]
+
+Expects:
+    -m <model_name>   Model name (e.g., base.en, small, medium, large)
+    -f <audio_file>   Path to audio file (WAV, 16kHz, mono preferred)
+    -l <language>     Optional language code (e.g., en, ru, he)
+    -o <output_dir>   Optional output directory for .txt file (default: same dir as audio)
+
+Output:
+    Writes <audio_file>.txt with the transcription text.
+    Exits with code 0 on success, non-zero on failure.
+"""
+
+import sys
+import os
+import struct
+import wave
+import argparse
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Whisper.cpp wrapper for EchOS")
+    parser.add_argument("-m", "--model", required=True, help="Model name")
+    parser.add_argument("-f", "--file", required=True, help="Audio file path (WAV)")
+    parser.add_argument("-l", "--language", default=None, help="Language code")
+    parser.add_argument("-o", "--output-dir", default=None, help="Output directory")
+    args = parser.parse_args()
+
+    # Import whispercpp
+    try:
+        from whispercpp import Whisper
+    except ImportError:
+        print(
+            "Error: whispercpp package not found. Install with: pip install whispercpp",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Load model
+    model_name = args.model.replace(".bin", "").replace("ggml-", "")
+    model_dir = os.environ.get(
+        "WHISPER_MODEL_DIR",
+        os.path.join(os.path.expanduser("~"), ".local", "share", "whispercpp"),
+    )
+    try:
+        w = Whisper.from_pretrained(model_name, basedir=model_dir)
+    except Exception as e:
+        print(f"Error loading model '{model_name}': {e}", file=sys.stderr)
+        sys.exit(1)
+
+    # Set language if specified
+    if args.language:
+        w.params.language = args.language
+
+    # Read WAV file and convert to float samples
+    audio_path = args.file
+    try:
+        with wave.open(audio_path, "rb") as wf:
+            n_frames = wf.getnframes()
+            raw = wf.readframes(n_frames)
+            samples = struct.unpack(f"<{n_frames}h", raw)
+            float_samples = [s / 32768.0 for s in samples]
+    except Exception as e:
+        print(f"Error reading audio file: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    # Transcribe
+    try:
+        result_code = w.context.full_parallel(w.params, float_samples, 1)
+        if result_code != 0:
+            print(f"Transcription failed with code {result_code}", file=sys.stderr)
+            sys.exit(1)
+    except Exception as e:
+        print(f"Error transcribing: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    # Extract text from segments
+    n_segments = w.context.full_n_segments()
+    text_parts = []
+    for i in range(n_segments):
+        segment_text = w.context.full_get_segment_text(i)
+        if segment_text:
+            text_parts.append(segment_text)
+
+    text = " ".join(text_parts).strip()
+
+    # Write output
+    output_dir = args.output_dir or os.path.dirname(audio_path) or "."
+    output_path = os.path.join(output_dir, os.path.basename(audio_path) + ".txt")
+    try:
+        with open(output_path, "w") as f:
+            f.write(text)
+    except Exception as e:
+        print(f"Error writing output: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    print(text)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/agent-deps.ts
+++ b/src/agent-deps.ts
@@ -5,19 +5,26 @@
 import { join } from 'node:path';
 import type { Logger } from 'pino';
 import type { Config } from '@echos/shared';
-import type { AgentDeps, PluginRegistry } from '@echos/core';
+import type { AgentDeps, PluginRegistry, SpeechToTextClient } from '@echos/core';
 import type { StorageResult } from './storage-init.js';
 import type { createManageScheduleTool } from '@echos/scheduler';
 
-export function buildPluginConfig(config: Config): Record<string, unknown> {
+export function buildPluginConfig(
+  config: Config,
+  sttClient: SpeechToTextClient,
+): Record<string, unknown> {
   return {
     ...(config.openaiApiKey ? { openaiApiKey: config.openaiApiKey } : {}),
     ...(config.whisperLanguage ? { whisperLanguage: config.whisperLanguage } : {}),
     ...(config.anthropicApiKey ? { anthropicApiKey: config.anthropicApiKey } : {}),
     ...(config.llmApiKey ? { llmApiKey: config.llmApiKey } : {}),
     ...(config.llmBaseUrl ? { llmBaseUrl: config.llmBaseUrl } : {}),
-    ...(config.webshareProxyUsername ? { webshareProxyUsername: config.webshareProxyUsername } : {}),
-    ...(config.webshareProxyPassword ? { webshareProxyPassword: config.webshareProxyPassword } : {}),
+    ...(config.webshareProxyUsername
+      ? { webshareProxyUsername: config.webshareProxyUsername }
+      : {}),
+    ...(config.webshareProxyPassword
+      ? { webshareProxyPassword: config.webshareProxyPassword }
+      : {}),
     knowledgeDir: config.knowledgeDir,
     defaultModel: config.defaultModel,
     dbPath: config.dbPath,
@@ -29,6 +36,7 @@ export function buildAgentDeps(
   storage: StorageResult,
   pluginRegistry: PluginRegistry,
   manageScheduleTool: ReturnType<typeof createManageScheduleTool>,
+  sttClient: SpeechToTextClient | undefined,
   logger: Logger,
 ): AgentDeps {
   return {
@@ -60,5 +68,6 @@ export function buildAgentDeps(
     backupRetentionCount: config.backupRetentionCount,
     knowledgeDir: config.knowledgeDir,
     dbPath: config.dbPath,
+    sttClient,
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,12 @@
  */
 import { join } from 'node:path';
 import { loadConfig, createLogger, type InterfaceAdapter } from '@echos/shared';
-import { PluginRegistry, type AgentDeps } from '@echos/core';
+import {
+  PluginRegistry,
+  type AgentDeps,
+  createSttClient,
+  type SpeechToTextClient,
+} from '@echos/core';
 import { createTelegramAdapter, type TelegramAdapter } from '@echos/telegram';
 import { createWebAdapter } from '@echos/web';
 import { createManageScheduleTool } from '@echos/scheduler';
@@ -23,26 +28,47 @@ async function main(): Promise<void> {
 
   const storage = await initStorage(config, logger);
 
+  const sttClient: SpeechToTextClient | undefined = await createSttClient(config);
+  if (sttClient) {
+    logger.info({ provider: config.sttProvider, model: config.sttModel }, 'STT client created');
+  } else {
+    logger.warn('STT not configured — voice messages and audio transcription will be unavailable');
+  }
+
   const pluginRegistry = new PluginRegistry(logger);
   for (const plugin of await loadPlugins(logger)) pluginRegistry.register(plugin);
 
   let notificationService: import('@echos/shared').NotificationService;
   await pluginRegistry.setupAll({
-    sqlite: storage.sqlite, markdown: storage.markdown, vectorDb: storage.vectorDb,
-    generateEmbedding: storage.generateEmbedding, logger,
-    getAgentDeps: () => agentDeps, getNotificationService: () => notificationService,
-    config: buildPluginConfig(config),
+    sqlite: storage.sqlite,
+    markdown: storage.markdown,
+    vectorDb: storage.vectorDb,
+    generateEmbedding: storage.generateEmbedding,
+    logger,
+    getAgentDeps: () => agentDeps,
+    getNotificationService: () => notificationService,
+    sttClient,
+    config: buildPluginConfig(config, sttClient),
   });
 
   const redisResult = await checkRedisConnection(config.redisUrl, logger);
   if (!redisResult.ok) {
-    logger.fatal({ redisError: redisResult.error },
-      'Redis is not reachable — install and start Redis, then restart EchOS (pnpm redis:start)');
+    logger.fatal(
+      { redisError: redisResult.error },
+      'Redis is not reachable — install and start Redis, then restart EchOS (pnpm redis:start)',
+    );
     process.exit(1);
   }
 
   const manageScheduleTool = createManageScheduleTool({ sqlite: storage.sqlite });
-  const agentDeps: AgentDeps = buildAgentDeps(config, storage, pluginRegistry, manageScheduleTool, logger);
+  const agentDeps: AgentDeps = buildAgentDeps(
+    config,
+    storage,
+    pluginRegistry,
+    manageScheduleTool,
+    sttClient,
+    logger,
+  );
   const interfaces: InterfaceAdapter[] = [];
   let telegramAdapter: TelegramAdapter | undefined;
   if (config.enableTelegram) {
@@ -51,30 +77,55 @@ async function main(): Promise<void> {
   }
 
   notificationService = telegramAdapter?.notificationService ?? {
-    sendMessage: async (userId: number, text: string) => { logger.info({ userId, text }, 'Notification (no channel)'); },
-    broadcast: async (text: string) => { logger.info({ text }, 'Broadcast (no channel)'); },
+    sendMessage: async (userId: number, text: string) => {
+      logger.info({ userId, text }, 'Notification (no channel)');
+    },
+    broadcast: async (text: string) => {
+      logger.info({ text }, 'Broadcast (no channel)');
+    },
   };
 
   const scheduler = await setupScheduler(
-    config, storage, pluginRegistry, notificationService, manageScheduleTool, logger);
+    config,
+    storage,
+    pluginRegistry,
+    notificationService,
+    manageScheduleTool,
+    sttClient,
+    logger,
+  );
 
   if (config.enableWeb) {
-    interfaces.push(createWebAdapter({
-      config, agentDeps, logger, exportsDir: join(config.dbPath, '..', 'exports'),
-      syncSchedule: scheduler.syncSchedule, deleteSchedule: scheduler.deleteSchedule,
-    }));
+    interfaces.push(
+      createWebAdapter({
+        config,
+        agentDeps,
+        logger,
+        exportsDir: join(config.dbPath, '..', 'exports'),
+        syncSchedule: scheduler.syncSchedule,
+        deleteSchedule: scheduler.deleteSchedule,
+      }),
+    );
   }
 
   for (const iface of interfaces) await iface.start();
   logger.info({ interfaceCount: interfaces.length }, 'EchOS started');
 
   const shutdown = createShutdownHandler({
-    worker: scheduler.worker, queueService: scheduler.queueService,
-    fileWatcher: storage.fileWatcher, interfaces, pluginRegistry,
-    sqlite: storage.sqlite, vectorDb: storage.vectorDb, logger,
+    worker: scheduler.worker,
+    queueService: scheduler.queueService,
+    fileWatcher: storage.fileWatcher,
+    interfaces,
+    pluginRegistry,
+    sqlite: storage.sqlite,
+    vectorDb: storage.vectorDb,
+    logger,
   });
   process.on('SIGINT', () => void shutdown());
   process.on('SIGTERM', () => void shutdown());
 }
 
-main().catch((err) => { logger.fatal({ err }, 'Fatal error'); process.exit(1); });
+main().catch((err) => {
+  logger.fatal({ err }, 'Fatal error');
+  process.exit(1);
+});

--- a/src/scheduler-setup.ts
+++ b/src/scheduler-setup.ts
@@ -6,7 +6,7 @@
 import { join } from 'node:path';
 import type { Logger } from 'pino';
 import type { Config, NotificationService } from '@echos/shared';
-import type { PluginRegistry } from '@echos/core';
+import type { PluginRegistry, SpeechToTextClient } from '@echos/core';
 import type { StorageResult } from './storage-init.js';
 import {
   createQueue,
@@ -37,6 +37,7 @@ export async function setupScheduler(
   pluginRegistry: PluginRegistry,
   notificationService: NotificationService,
   manageScheduleTool: ReturnType<typeof createManageScheduleTool>,
+  sttClient: SpeechToTextClient,
   logger: Logger,
 ): Promise<SchedulerResult> {
   const exportsDir = join(config.dbPath, '..', 'exports');
@@ -55,7 +56,7 @@ export async function setupScheduler(
     vectorDb: storage.vectorDb,
     generateEmbedding: storage.generateEmbedding,
     logger,
-    ...(config.openaiApiKey ? { openaiApiKey: config.openaiApiKey } : {}),
+    sttClient,
     ...(config.whisperLanguage ? { whisperLanguage: config.whisperLanguage } : {}),
   });
 


### PR DESCRIPTION
## Summary

Add support for multiple Speech-to-Text (STT) providers with automatic detection and fallback.

### Features
- **Provider Registry**: Supports OpenAI, Groq, Together AI, SiliconFlow, DeepInfra, Fireworks AI, Hugging Face, OpenRouter, and local whisper.cpp
- **Auto-Detection**: Automatically detects provider from API key prefix, base URL, or model name
- **Probe Fallback**: Probes providers with opaque API keys via /models endpoint
- **Local Whisper Support**: Supports whisper.cpp, whispercpp Python, openai-whisper, faster-whisper
- **Retry Logic**: Exponential backoff for rate-limited transcription requests
- **73 Tests**: Comprehensive test coverage for all STT functionality

### Configuration

```bash
# Auto-detect from API key
STT_API_KEY=gsk_...

# Or explicit provider
STT_PROVIDER=groq
STT_API_KEY=...
STT_BASE_URL=...
STT_MODEL=...

# Or local whisper (offline)
STT_PROVIDER=local
STT_LOCAL_EXECUTABLE=/opt/homebrew/bin/whisper-cli
STT_LOCAL_MODEL=~/whisper-models/ggml-base.en.bin
```

### Changes
- New: `packages/core/src/stt/\* (6 files)
- Updated: config schema, plugin types, agent types, telegram voice, audio/youtube plugins, scheduler
- Documentation: Updated `.env.example` with all STT options