### PR TITLE
fix: sanitizeHtml re-encodes decoded entities, leaving HTML entities in markdown

### DIFF
--- a/packages/shared/src/security/sanitize.ts
+++ b/packages/shared/src/security/sanitize.ts
@@ -1,11 +1,3 @@
-const HTML_ENTITIES: Record<string, string> = {
-  '&': '&amp;',
-  '<': '&lt;',
-  '>': '&gt;',
-  '"': '&quot;',
-  "'": '&#x27;',
-};
-
 const XML_ENTITIES: Record<string, string> = {
   '&': '&amp;',
   '<': '&lt;',
@@ -38,8 +30,8 @@ export function sanitizeHtml(input: string): string {
     if (codePoint <= 0x1F && codePoint !== 9 && codePoint !== 10 && codePoint !== 13) return match;
     return String.fromCodePoint(codePoint);
   });
-  // Re-escape for safety
-  clean = clean.replace(/[&<>"']/g, (char) => HTML_ENTITIES[char] ?? char);
+  // No re-encoding: all callers (YouTube, article) save to markdown, not HTML.
+  // Undecoded entities (invalid surrogates, control chars) keep their raw & which is fine in markdown.
   return clean.trim();
 }
 

--- a/packages/shared/src/security/security.test.ts
+++ b/packages/shared/src/security/security.test.ts
@@ -167,48 +167,47 @@ describe('timingSafeStringEqual', () => {
 describe('sanitizeHtml — HTML entity decoding', () => {
   it('decodes decimal numeric entities (e.g. &#39; → apostrophe)', () => {
     const result = sanitizeHtml('it&#39;s great');
-    expect(result).toBe('it&#x27;s great');
+    expect(result).toBe("it's great");
   });
 
   it('decodes hex numeric entities (e.g. &#x27; → apostrophe)', () => {
     const result = sanitizeHtml('it&#x27;s great');
-    expect(result).toBe('it&#x27;s great');
+    expect(result).toBe("it's great");
   });
 
   it('decodes uppercase hex numeric entities (e.g. &#X27; → apostrophe)', () => {
     const result = sanitizeHtml('it&#X27;s great');
-    expect(result).toBe('it&#x27;s great');
+    expect(result).toBe("it's great");
   });
 
   it('does not double-encode decimal apostrophe entities from YouTube transcripts', () => {
     const youtubeSnippet = 'it&#39;s a great video';
     const result = sanitizeHtml(youtubeSnippet);
-    expect(result).not.toContain('&amp;#39;');
-    expect(result).not.toContain('&amp;#x27;');
+    expect(result).toBe("it's a great video");
   });
 
   it('does not crash on invalid surrogate numeric entities and sanitizes the ampersand', () => {
     const result = sanitizeHtml('&#55296;'); // 0xD800 — invalid surrogate
-    // Entity is not decoded; the & is re-escaped, producing &amp;#55296;
-    expect(result).toBe('&amp;#55296;');
+    // Entity is not decoded; raw entity preserved as-is
+    expect(result).toBe('&#55296;');
     expect(result).not.toContain('\uD800'); // no actual surrogate character
   });
 
   it('does not crash on out-of-range numeric entities and sanitizes the ampersand', () => {
     const result = sanitizeHtml('&#1114112;'); // 0x110000 — above max code point
-    // Entity is not decoded; the & is re-escaped, producing &amp;#1114112;
-    expect(result).toBe('&amp;#1114112;');
+    // Entity is not decoded; raw entity preserved as-is
+    expect(result).toBe('&#1114112;');
   });
 
   it('rejects C0 control character entities (except TAB, LF, CR)', () => {
     // NUL (&#0;) should not be decoded
     const nul = sanitizeHtml('a&#0;b');
-    expect(nul).toBe('a&amp;#0;b');
+    expect(nul).toBe('a&#0;b');
     expect(nul).not.toContain('\0');
 
     // BEL (&#7;) should not be decoded
     const bel = sanitizeHtml('a&#7;b');
-    expect(bel).toBe('a&amp;#7;b');
+    expect(bel).toBe('a&#7;b');
 
     // TAB (&#9;), LF (&#10;), CR (&#13;) ARE allowed
     expect(sanitizeHtml('a&#9;b')).toBe('a\tb');
@@ -216,13 +215,13 @@ describe('sanitizeHtml — HTML entity decoding', () => {
     expect(sanitizeHtml('a&#13;b')).toBe('a\rb');
   });
 
-  it('strips HTML tags and re-encodes special characters', () => {
+  it('strips HTML tags and preserves decoded text', () => {
     const result = sanitizeHtml('<b>hello & world</b>');
-    expect(result).toBe('hello &amp; world');
+    expect(result).toBe('hello & world');
   });
 
-  it('decodes &amp; and re-encodes it once', () => {
+  it('decodes &amp; to &', () => {
     const result = sanitizeHtml('A &amp; B');
-    expect(result).toBe('A &amp; B');
+    expect(result).toBe('A & B');
   });
 });


### PR DESCRIPTION
## Summary

`sanitizeHtml()` decodes HTML entities then immediately re-encodes them, making the decode step a no-op:

```
&#x27;  →  '  →  &#x27;   (round-trip, no change)
&amp;   →  &  →  &amp;    (round-trip, no change)
&#39;   →  '  →  &#x27;   (decoded then re-encoded differently)
```

This causes YouTube transcripts and article content to be saved with raw HTML entities like `&#x27;` (apostrophes) and `&amp;` in markdown notes. For example, "it's" appears as "it&#x27;s" in saved notes.

**Root cause:** The re-encode step on line 40 (`clean.replace(/[&<>"']/g, ...)`) was added for XSS safety, but all callers save to markdown files, not HTML.

## Changes

- Remove the re-encode step from `sanitizeHtml()` — output is now decoded plain text
- Remove the unused `HTML_ENTITIES` constant
- Update test expectations to match decoded output
- `escapeXml()` is unaffected (it has its own entity map)

## Test plan

- [x] Updated all `sanitizeHtml` test cases to expect decoded plain text
- [x] Verified `&#39;` / `&#x27;` / `&#X27;` all decode to actual apostrophe
- [x] Verified invalid entities (surrogates, control chars) are preserved as-is
- [x] Verified HTML tags are still stripped
- [x] Verified `&amp;` decodes to `&`

🤖 Generated with [Claude Code](https://claude.com/claude-code)