### PR TITLE
fix: decouple Docker healthcheck from ENABLE_WEB

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -32,7 +32,10 @@ services:
     ports:
       - "${WEB_PORT:-3000}:3000"
     healthcheck:
-      test: ["CMD", "node", "-e", "fetch('http://localhost:3000/health').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"]
+      # Checks the process's liveness heartbeat file (src/heartbeat.ts) rather than the
+      # web interface's /health endpoint, since ENABLE_WEB=false leaves nothing listening
+      # on port 3000.
+      test: ["CMD", "node", "-e", "const fs=require('fs');try{process.exit(Date.now()-fs.statSync('/tmp/echos-heartbeat').mtimeMs<60000?0:1)}catch{process.exit(1)}"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docs/deployment.mdx
+++ b/docs/deployment.mdx
@@ -38,7 +38,7 @@ docker compose down
 
 Services:
 - **redis**: Redis 7 for BullMQ job queue (required)
-- **echos**: The EchOS application (healthcheck: GET /health)
+- **echos**: The EchOS application (healthcheck: liveness heartbeat file, independent of `ENABLE_WEB` — see [Troubleshooting](/troubleshooting#docker-compose-ps-shows-echos-as-unhealthy-even-though-its-working))
 
 Data is persisted via volume mounts to `./data/`.
 

--- a/docs/setup-fixes.mdx
+++ b/docs/setup-fixes.mdx
@@ -7,6 +7,19 @@ description: "Configuration changes and fixes log."
 
 This document tracks configuration changes and fixes made to ensure the project runs correctly.
 
+## July 2026 — Docker healthcheck decoupled from `ENABLE_WEB`
+
+### Problem
+
+The `echos` service's Docker healthcheck (`docker/docker-compose.yml`) fetched `http://localhost:3000/health`, which is served by the web interface (`packages/web`). On Telegram-only deployments (`ENABLE_WEB=false`), nothing listens on port 3000, so `docker compose ps` reported the container as permanently "unhealthy" regardless of actual health — masking real incidents (e.g. a genuinely wedged process after a host OOM kill looked no different from normal operation).
+
+### Fix
+
+- New `src/heartbeat.ts`: writes `/tmp/echos-heartbeat` every 15s, started unconditionally in `src/index.ts` alongside the other interfaces (not gated by `ENABLE_WEB`/`ENABLE_TELEGRAM`/`ENABLE_MCP`), stopped via `src/shutdown.ts`.
+- `docker/docker-compose.yml`: healthcheck now checks the heartbeat file's age instead of fetching `/health`.
+
+The web interface's own `GET /health` endpoint (`packages/web/src/index.ts`) is unchanged and still useful for external uptime monitoring when `ENABLE_WEB=true`.
+
 ## April 2026 — MCP Server Core (Phase 11.01)
 
 ### New env vars: `ENABLE_MCP`, `MCP_PORT`, `MCP_API_KEY`

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -423,6 +423,36 @@ Error: ENOENT: no such file or directory
    pnpm start
    ```
 
+### `docker compose ps` shows echos as unhealthy even though it's working
+
+**Problem**: Prior to this fix, the Docker healthcheck did `fetch('http://localhost:3000/health')`, which is served by the web interface (`packages/web`). If `ENABLE_WEB=false` (e.g. Telegram-only deployments), nothing ever listens on port 3000, so the healthcheck failed permanently — even on a perfectly healthy container. This made `docker compose ps` useless for spotting real problems, since "unhealthy" was the permanent baseline rather than a meaningful signal.
+
+**Fix**: The healthcheck now checks a liveness heartbeat file (`/tmp/echos-heartbeat`, written every 15s by `src/heartbeat.ts`) instead of the web interface's `/health` endpoint. This works regardless of `ENABLE_WEB`/`ENABLE_TELEGRAM`/`ENABLE_MCP` and still catches a wedged event loop (a hung process stops writing the heartbeat, same as it would stop responding to HTTP).
+
+**If you're still seeing "unhealthy"** after upgrading:
+
+```bash
+# Confirm the container's own process can see a recent heartbeat
+docker compose exec echos node -e "const fs=require('fs');console.log(Date.now()-fs.statSync('/tmp/echos-heartbeat').mtimeMs, 'ms old')"
+
+# If docker exec itself fails ("cannot exec in a stopped state") while docker inspect
+# still reports Running=true, the container is likely wedged (e.g. after an OOM kill
+# on a memory-constrained host) and Docker hasn't detected the exit. Force-recreate it:
+docker compose up -d --force-recreate echos
+```
+
+On low-memory hosts (e.g. Oracle Cloud's free-tier `VM.Standard.E2.1.Micro`, 1GB RAM / no swap), a wedged-but-still-"Running" container after an OOM kill is the most common root cause. Check `dmesg -T | grep -i oom` on the host for confirmation, and add swap so transient spikes (e.g. the `backup` job's `tar`/`cp` work) don't trigger the OOM-killer:
+
+```bash
+sudo fallocate -l 2G /swapfile
+sudo chmod 600 /swapfile
+sudo mkswap /swapfile
+sudo swapon /swapfile
+echo '/swapfile none swap sw 0 0' | sudo tee -a /etc/fstab
+echo 'vm.swappiness=10' | sudo tee /etc/sysctl.d/99-swappiness.conf
+sudo sysctl --system
+```
+
 ## Development Issues
 
 ### TypeScript Errors

--- a/src/heartbeat.ts
+++ b/src/heartbeat.ts
@@ -1,0 +1,34 @@
+/**
+ * Liveness heartbeat.
+ * Periodically touches a file so the Docker healthcheck can detect a wedged
+ * event loop without depending on the (optional) web interface's /health
+ * endpoint, which is unavailable whenever ENABLE_WEB=false.
+ */
+
+import { writeFile } from 'node:fs/promises';
+import type { Logger } from 'pino';
+
+export const HEARTBEAT_PATH = '/tmp/echos-heartbeat';
+const HEARTBEAT_INTERVAL_MS = 15_000;
+
+export interface Heartbeat {
+  stop(): void;
+}
+
+export function startHeartbeat(logger: Logger): Heartbeat {
+  const beat = (): void => {
+    writeFile(HEARTBEAT_PATH, String(Date.now())).catch((err: unknown) => {
+      logger.warn({ err }, 'Failed to write heartbeat file');
+    });
+  };
+
+  beat();
+  const interval = setInterval(beat, HEARTBEAT_INTERVAL_MS);
+  interval.unref();
+
+  return {
+    stop(): void {
+      clearInterval(interval);
+    },
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import { loadPlugins } from './plugin-loader.js';
 import { setupScheduler } from './scheduler-setup.js';
 import { createShutdownHandler } from './shutdown.js';
 import { buildPluginConfig, buildAgentDeps } from './agent-deps.js';
+import { startHeartbeat } from './heartbeat.js';
 
 const logger = createLogger('echos');
 
@@ -84,10 +85,12 @@ async function main(): Promise<void> {
   for (const iface of interfaces) await iface.start();
   logger.info({ interfaceCount: interfaces.length }, 'EchOS started');
 
+  const heartbeat = startHeartbeat(logger);
+
   const shutdown = createShutdownHandler({
     worker: scheduler.worker, queueService: scheduler.queueService,
     fileWatcher: storage.fileWatcher, interfaces, pluginRegistry,
-    sqlite: storage.sqlite, vectorDb: storage.vectorDb, logger,
+    sqlite: storage.sqlite, vectorDb: storage.vectorDb, logger, heartbeat,
   });
   process.on('SIGINT', () => void shutdown());
   process.on('SIGTERM', () => void shutdown());

--- a/src/shutdown.ts
+++ b/src/shutdown.ts
@@ -7,6 +7,7 @@ import type { Logger } from 'pino';
 import type { InterfaceAdapter } from '@echos/shared';
 import type { PluginRegistry, FileWatcher } from '@echos/core';
 import type { QueueService } from '@echos/scheduler';
+import type { Heartbeat } from './heartbeat.js';
 
 export interface ShutdownResources {
   worker?: { close(): Promise<void> };
@@ -17,11 +18,13 @@ export interface ShutdownResources {
   sqlite: { close(): void };
   vectorDb: { close(): void };
   logger: Logger;
+  heartbeat: Heartbeat;
 }
 
 export function createShutdownHandler(resources: ShutdownResources): () => Promise<void> {
   return async () => {
     resources.logger.info('Shutting down...');
+    resources.heartbeat.stop();
 
     if (resources.worker) {
       await resources.worker.close();


### PR DESCRIPTION
## Summary
- The `echos` service's Docker healthcheck fetched the web interface's `/health` endpoint (`http://localhost:3000/health`). On Telegram-only deployments (`ENABLE_WEB=false`), nothing ever listens on port 3000, so `docker compose ps` reported the container as permanently "unhealthy" — regardless of actual health.
- This surfaced in production: a host OOM kill left the container genuinely wedged for days (`docker exec` failing with "cannot exec in a stopped state", `docker stats` showing 0 PIDs), but since "unhealthy" was already the permanent baseline for this config, the real incident went unnoticed.
- Adds a liveness heartbeat file (`src/heartbeat.ts`), written every 15s regardless of which interfaces (`ENABLE_WEB`/`ENABLE_TELEGRAM`/`ENABLE_MCP`) are enabled, and points the Docker healthcheck at that instead of the web `/health` endpoint. The web interface's own `/health` route is unchanged and still useful for external uptime monitoring when `ENABLE_WEB=true`.

## Test plan
- [x] `pnpm -r build` — passes
- [x] `pnpm vitest run` — 665/665 tests pass
- [x] Verified manually against a live deployment (Telegram-only, `ENABLE_WEB=false`): confirmed `fetch('http://localhost:3000/health')` fails with `ECONNREFUSED` on the old healthcheck; new heartbeat-file approach reflects real process liveness independent of which interfaces are enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)